### PR TITLE
Fix ESP32 firmware dependency bootstrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 build/
 .vscode/
 .deps/
-core/lib/
-core/include/rapidjson/
-core/include/yoga/
-core/include/lodepng.h
-core/include/tjpgd.h
-core/include/tjpgdcnf.h
 ports/esp32/lib/
 ports/esp32/.pio/
 

--- a/cmake/MultigaugeDependencies.cmake
+++ b/cmake/MultigaugeDependencies.cmake
@@ -11,8 +11,36 @@ if(NOT DEFINED MULTIGAUGE_DEPS_DIR)
   set(MULTIGAUGE_DEPS_DIR "${MULTIGAUGE_SOURCE_DIR}/.deps")
 endif()
 
-set(MULTIGAUGE_CORE_LIB_DIR "${MULTIGAUGE_SOURCE_DIR}/core/lib")
-set(MULTIGAUGE_ESP32_LIB_DIR "${MULTIGAUGE_SOURCE_DIR}/ports/esp32/lib")
+# Single source of truth for third-party dependency locations and versions.
+set(MULTIGAUGE_DEP_RAPIDJSON_URL "https://github.com/Tencent/rapidjson.git")
+set(MULTIGAUGE_DEP_RAPIDJSON_TAG "v1.1.0")
+set(MULTIGAUGE_DEP_RAPIDJSON_DIR "${MULTIGAUGE_DEPS_DIR}/rapidjson")
+
+set(MULTIGAUGE_DEP_YOGA_URL "https://github.com/facebook/yoga.git")
+set(MULTIGAUGE_DEP_YOGA_TAG "v2.0.0")
+set(MULTIGAUGE_DEP_YOGA_DIR "${MULTIGAUGE_DEPS_DIR}/yoga")
+
+set(MULTIGAUGE_DEP_LODEPNG_DIR "${MULTIGAUGE_DEPS_DIR}/lodepng")
+set(MULTIGAUGE_DEP_LODEPNG_CPP_URL "https://raw.githubusercontent.com/lvandeve/lodepng/master/lodepng.cpp")
+set(MULTIGAUGE_DEP_LODEPNG_H_URL "https://raw.githubusercontent.com/lvandeve/lodepng/master/lodepng.h")
+
+set(MULTIGAUGE_DEP_TJPGD_DIR "${MULTIGAUGE_DEPS_DIR}/tjpgd")
+set(MULTIGAUGE_DEP_TJPGD_C_URL "https://raw.githubusercontent.com/cmumford/TJpgDec/master/src/tjpgd.c")
+set(MULTIGAUGE_DEP_TJPGD_H_URL "https://raw.githubusercontent.com/cmumford/TJpgDec/master/src/tjpgd.h")
+set(MULTIGAUGE_DEP_TJPGD_CONFIG_URL "https://raw.githubusercontent.com/cmumford/TJpgDec/master/src/tjpgdcnf.h")
+
+set(MULTIGAUGE_DEP_ASYNCTCP_URL "https://github.com/me-no-dev/AsyncTCP.git")
+set(MULTIGAUGE_DEP_ASYNCTCP_TAG "master")
+set(MULTIGAUGE_DEP_ASYNCTCP_DIR "${MULTIGAUGE_DEPS_DIR}/AsyncTCP")
+
+set(MULTIGAUGE_DEP_ESPASYNCWEBSERVER_URL "https://github.com/me-no-dev/ESPAsyncWebServer.git")
+set(MULTIGAUGE_DEP_ESPASYNCWEBSERVER_TAG "master")
+set(MULTIGAUGE_DEP_ESPASYNCWEBSERVER_VERSION "3.6.0")
+set(MULTIGAUGE_DEP_ESPASYNCWEBSERVER_DIR "${MULTIGAUGE_DEPS_DIR}/ESPAsyncWebServer")
+
+set(MULTIGAUGE_DEP_LOVYANGFX_URL "https://github.com/lovyan03/LovyanGFX.git")
+set(MULTIGAUGE_DEP_LOVYANGFX_TAG "1.2.0")
+set(MULTIGAUGE_DEP_LOVYANGFX_DIR "${MULTIGAUGE_DEPS_DIR}/LovyanGFX")
 
 function(multigauge_download_file url destination)
   if(EXISTS "${destination}")
@@ -65,6 +93,18 @@ function(multigauge_clone_repo url tag destination)
   endif()
 
   file(WRITE "${destination}/.multigauge-ready" "ok\n")
+endfunction()
+
+function(multigauge_clone_dependency name)
+  set(url_var "MULTIGAUGE_DEP_${name}_URL")
+  set(tag_var "MULTIGAUGE_DEP_${name}_TAG")
+  set(dir_var "MULTIGAUGE_DEP_${name}_DIR")
+
+  if(NOT DEFINED ${url_var} OR NOT DEFINED ${tag_var} OR NOT DEFINED ${dir_var})
+    message(FATAL_ERROR "Unknown multigauge dependency '${name}'")
+  endif()
+
+  multigauge_clone_repo("${${url_var}}" "${${tag_var}}" "${${dir_var}}")
 endfunction()
 
 function(multigauge_copy_or_link_directory target link)
@@ -134,79 +174,3 @@ function(multigauge_patch_rapidjson rapidjson_include_dir)
     file(WRITE "${document_header}" "${patched_content}")
   endif()
 endfunction()
-
-function(multigauge_bootstrap_dependencies)
-  file(MAKE_DIRECTORY "${MULTIGAUGE_DEPS_DIR}")
-
-  # Shared core dependencies.
-  multigauge_clone_repo(
-    "https://github.com/Tencent/rapidjson.git"
-    "v1.1.0"
-    "${MULTIGAUGE_DEPS_DIR}/rapidjson"
-  )
-  multigauge_patch_rapidjson("${MULTIGAUGE_DEPS_DIR}/rapidjson/include")
-
-  multigauge_clone_repo(
-    "https://github.com/facebook/yoga.git"
-    "v2.0.0"
-    "${MULTIGAUGE_DEPS_DIR}/yoga"
-  )
-
-  multigauge_download_file(
-    "https://raw.githubusercontent.com/lvandeve/lodepng/master/lodepng.cpp"
-    "${MULTIGAUGE_DEPS_DIR}/lodepng/lodepng.cpp"
-  )
-  multigauge_download_file(
-    "https://raw.githubusercontent.com/lvandeve/lodepng/master/lodepng.h"
-    "${MULTIGAUGE_DEPS_DIR}/lodepng/lodepng.h"
-  )
-
-  multigauge_download_file(
-    "https://raw.githubusercontent.com/cmumford/TJpgDec/master/src/tjpgd.c"
-    "${MULTIGAUGE_DEPS_DIR}/tjpgd/tjpgd.c"
-  )
-  multigauge_download_file(
-    "https://raw.githubusercontent.com/cmumford/TJpgDec/master/src/tjpgd.h"
-    "${MULTIGAUGE_DEPS_DIR}/tjpgd/tjpgd.h"
-  )
-  multigauge_download_file(
-    "https://raw.githubusercontent.com/cmumford/TJpgDec/master/src/tjpgdcnf.h"
-    "${MULTIGAUGE_DEPS_DIR}/tjpgd/tjpgdcnf.h"
-  )
-
-  # ESP32-specific dependencies.
-  multigauge_clone_repo(
-    "https://github.com/me-no-dev/AsyncTCP.git"
-    "master"
-    "${MULTIGAUGE_DEPS_DIR}/AsyncTCP"
-  )
-  multigauge_clone_repo(
-    "https://github.com/me-no-dev/ESPAsyncWebServer.git"
-    "master"
-    "${MULTIGAUGE_DEPS_DIR}/ESPAsyncWebServer"
-  )
-  multigauge_clone_repo(
-    "https://github.com/lovyan03/LovyanGFX.git"
-    "1.2.0"
-    "${MULTIGAUGE_DEPS_DIR}/LovyanGFX"
-  )
-
-  # Legacy build-system compatibility directories.
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/rapidjson/include" "${MULTIGAUGE_CORE_LIB_DIR}/rapidjson/src")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/yoga/yoga" "${MULTIGAUGE_CORE_LIB_DIR}/yoga/src")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/lodepng" "${MULTIGAUGE_CORE_LIB_DIR}/lodepng/src")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/tjpgd" "${MULTIGAUGE_CORE_LIB_DIR}/tjpgd/src")
-
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/rapidjson/include/rapidjson" "${MULTIGAUGE_SOURCE_DIR}/core/include/rapidjson")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/yoga/yoga" "${MULTIGAUGE_SOURCE_DIR}/core/include/yoga")
-  multigauge_copy_file("${MULTIGAUGE_DEPS_DIR}/lodepng/lodepng.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/lodepng.h")
-  multigauge_copy_file("${MULTIGAUGE_DEPS_DIR}/tjpgd/tjpgd.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/tjpgd.h")
-  multigauge_copy_file("${MULTIGAUGE_DEPS_DIR}/tjpgd/tjpgdcnf.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/tjpgdcnf.h")
-
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/AsyncTCP" "${MULTIGAUGE_ESP32_LIB_DIR}/AsyncTCP-master")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/ESPAsyncWebServer" "${MULTIGAUGE_ESP32_LIB_DIR}/ESPAsyncWebServer-master")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEPS_DIR}/LovyanGFX" "${MULTIGAUGE_ESP32_LIB_DIR}/LovyanGFX")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_SOURCE_DIR}/core" "${MULTIGAUGE_ESP32_LIB_DIR}/multigauge-core")
-endfunction()
-
-multigauge_bootstrap_dependencies()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -7,7 +7,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 
-include("${CMAKE_CURRENT_LIST_DIR}/../cmake/MultigaugeDependencies.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/Dependencies.cmake")
+multigauge_bootstrap_core_dependencies()
 
 set(MULTIGAUGE_RAPIDJSON_INCLUDE_DIR "${MULTIGAUGE_DEPS_DIR}/rapidjson/include")
 set(MULTIGAUGE_YOGA_SOURCE_DIR "${MULTIGAUGE_DEPS_DIR}/yoga/yoga")

--- a/core/cmake/BootstrapDependencies.cmake
+++ b/core/cmake/BootstrapDependencies.cmake
@@ -1,0 +1,3 @@
+include("${CMAKE_CURRENT_LIST_DIR}/Dependencies.cmake")
+
+multigauge_bootstrap_core_dependencies()

--- a/core/cmake/Dependencies.cmake
+++ b/core/cmake/Dependencies.cmake
@@ -1,0 +1,45 @@
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/MultigaugeDependencies.cmake")
+
+set(MULTIGAUGE_CORE_LIB_DIR "${MULTIGAUGE_SOURCE_DIR}/core/lib")
+
+function(multigauge_bootstrap_core_dependencies)
+  file(MAKE_DIRECTORY "${MULTIGAUGE_DEPS_DIR}")
+
+  multigauge_clone_dependency(RAPIDJSON)
+  multigauge_patch_rapidjson("${MULTIGAUGE_DEP_RAPIDJSON_DIR}/include")
+
+  multigauge_clone_dependency(YOGA)
+
+  multigauge_download_file(
+    "${MULTIGAUGE_DEP_LODEPNG_CPP_URL}"
+    "${MULTIGAUGE_DEP_LODEPNG_DIR}/lodepng.cpp"
+  )
+  multigauge_download_file(
+    "${MULTIGAUGE_DEP_LODEPNG_H_URL}"
+    "${MULTIGAUGE_DEP_LODEPNG_DIR}/lodepng.h"
+  )
+
+  multigauge_download_file(
+    "${MULTIGAUGE_DEP_TJPGD_C_URL}"
+    "${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgd.c"
+  )
+  multigauge_download_file(
+    "${MULTIGAUGE_DEP_TJPGD_H_URL}"
+    "${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgd.h"
+  )
+  multigauge_download_file(
+    "${MULTIGAUGE_DEP_TJPGD_CONFIG_URL}"
+    "${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgdcnf.h"
+  )
+
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_RAPIDJSON_DIR}/include" "${MULTIGAUGE_CORE_LIB_DIR}/rapidjson/src")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_YOGA_DIR}/yoga" "${MULTIGAUGE_CORE_LIB_DIR}/yoga/src")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_LODEPNG_DIR}" "${MULTIGAUGE_CORE_LIB_DIR}/lodepng/src")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_TJPGD_DIR}" "${MULTIGAUGE_CORE_LIB_DIR}/tjpgd/src")
+
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_RAPIDJSON_DIR}/include/rapidjson" "${MULTIGAUGE_SOURCE_DIR}/core/include/rapidjson")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_YOGA_DIR}/yoga" "${MULTIGAUGE_SOURCE_DIR}/core/include/yoga")
+  multigauge_copy_file("${MULTIGAUGE_DEP_LODEPNG_DIR}/lodepng.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/lodepng.h")
+  multigauge_copy_file("${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgd.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/tjpgd.h")
+  multigauge_copy_file("${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgdcnf.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/tjpgdcnf.h")
+endfunction()

--- a/core/cmake/Dependencies.cmake
+++ b/core/cmake/Dependencies.cmake
@@ -1,7 +1,5 @@
 include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/MultigaugeDependencies.cmake")
 
-set(MULTIGAUGE_CORE_LIB_DIR "${MULTIGAUGE_SOURCE_DIR}/core/lib")
-
 function(multigauge_bootstrap_core_dependencies)
   file(MAKE_DIRECTORY "${MULTIGAUGE_DEPS_DIR}")
 
@@ -31,15 +29,4 @@ function(multigauge_bootstrap_core_dependencies)
     "${MULTIGAUGE_DEP_TJPGD_CONFIG_URL}"
     "${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgdcnf.h"
   )
-
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_RAPIDJSON_DIR}/include" "${MULTIGAUGE_CORE_LIB_DIR}/rapidjson/src")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_YOGA_DIR}/yoga" "${MULTIGAUGE_CORE_LIB_DIR}/yoga/src")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_LODEPNG_DIR}" "${MULTIGAUGE_CORE_LIB_DIR}/lodepng/src")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_TJPGD_DIR}" "${MULTIGAUGE_CORE_LIB_DIR}/tjpgd/src")
-
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_RAPIDJSON_DIR}/include/rapidjson" "${MULTIGAUGE_SOURCE_DIR}/core/include/rapidjson")
-  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_YOGA_DIR}/yoga" "${MULTIGAUGE_SOURCE_DIR}/core/include/yoga")
-  multigauge_copy_file("${MULTIGAUGE_DEP_LODEPNG_DIR}/lodepng.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/lodepng.h")
-  multigauge_copy_file("${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgd.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/tjpgd.h")
-  multigauge_copy_file("${MULTIGAUGE_DEP_TJPGD_DIR}/tjpgdcnf.h" "${MULTIGAUGE_SOURCE_DIR}/core/include/tjpgdcnf.h")
 endfunction()

--- a/core/library.json
+++ b/core/library.json
@@ -4,16 +4,24 @@
     "srcDir": ".",
     "includeDir": "include",
     "srcFilter": [
-      "+<src/**>",
-      "+<lib/yoga/src/**>",
-      "+<*>",
-      "+<lib/lodepng/src/lodepng.cpp>"
+      "+<src/**>"
     ],
     "flags": [
-      "-Ilib/rapidjson/src",
-      "-Ilib/lodepng/src",
-      "-Ilib/tjpgd/src",
-      "-Ilib/yoga/src"
+      "-I../.deps/rapidjson/include",
+      "-I../.deps/lodepng",
+      "-I../.deps/tjpgd",
+      "-I../.deps/yoga"
     ]
-  }
+  },
+  "dependencies": [
+    {
+      "name": "multigauge-yoga"
+    },
+    {
+      "name": "multigauge-lodepng"
+    },
+    {
+      "name": "multigauge-tjpgd"
+    }
+  ]
 }

--- a/ports/esp32/.gitignore
+++ b/ports/esp32/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/ports/esp32/bootstrap-deps.py
+++ b/ports/esp32/bootstrap-deps.py
@@ -3,8 +3,9 @@ import subprocess
 
 Import("env")  # noqa: F821
 
-root = Path(env["PROJECT_DIR"]).resolve().parents[1]
-script = root / "cmake" / "MultigaugeDependencies.cmake"
+port_dir = Path(env["PROJECT_DIR"]).resolve()
+root = port_dir.parents[1]
+script = port_dir / "cmake" / "BootstrapDependencies.cmake"
 
 subprocess.check_call(
     ["cmake", "-P", str(script)],

--- a/ports/esp32/cmake/BootstrapDependencies.cmake
+++ b/ports/esp32/cmake/BootstrapDependencies.cmake
@@ -1,0 +1,3 @@
+include("${CMAKE_CURRENT_LIST_DIR}/Dependencies.cmake")
+
+multigauge_bootstrap_esp32_port_dependencies()

--- a/ports/esp32/cmake/Dependencies.cmake
+++ b/ports/esp32/cmake/Dependencies.cmake
@@ -1,0 +1,36 @@
+include("${CMAKE_CURRENT_LIST_DIR}/../../../core/cmake/Dependencies.cmake")
+
+set(MULTIGAUGE_ESP32_LIB_DIR "${MULTIGAUGE_SOURCE_DIR}/ports/esp32/lib")
+
+function(multigauge_apply_espasyncwebserver_platformio_metadata library_dir)
+  set(library_json "${library_dir}/library.json")
+  set(override_template "${MULTIGAUGE_SOURCE_DIR}/ports/esp32/platformio-overrides/ESPAsyncWebServer.library.json.in")
+
+  if(NOT EXISTS "${library_json}" OR NOT EXISTS "${override_template}")
+    return()
+  endif()
+
+  configure_file("${override_template}" "${library_json}" @ONLY)
+endfunction()
+
+function(multigauge_bootstrap_esp32_dependencies)
+  file(MAKE_DIRECTORY "${MULTIGAUGE_DEPS_DIR}")
+
+  multigauge_clone_dependency(ASYNCTCP)
+
+  multigauge_clone_dependency(ESPASYNCWEBSERVER)
+  multigauge_apply_espasyncwebserver_platformio_metadata("${MULTIGAUGE_DEP_ESPASYNCWEBSERVER_DIR}")
+
+  multigauge_clone_dependency(LOVYANGFX)
+
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_ASYNCTCP_DIR}" "${MULTIGAUGE_ESP32_LIB_DIR}/AsyncTCP-master")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_ESPASYNCWEBSERVER_DIR}" "${MULTIGAUGE_ESP32_LIB_DIR}/ESPAsyncWebServer-master")
+  multigauge_apply_espasyncwebserver_platformio_metadata("${MULTIGAUGE_ESP32_LIB_DIR}/ESPAsyncWebServer-master")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_LOVYANGFX_DIR}" "${MULTIGAUGE_ESP32_LIB_DIR}/LovyanGFX")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_SOURCE_DIR}/core" "${MULTIGAUGE_ESP32_LIB_DIR}/multigauge-core")
+endfunction()
+
+function(multigauge_bootstrap_esp32_port_dependencies)
+  multigauge_bootstrap_core_dependencies()
+  multigauge_bootstrap_esp32_dependencies()
+endfunction()

--- a/ports/esp32/cmake/Dependencies.cmake
+++ b/ports/esp32/cmake/Dependencies.cmake
@@ -2,6 +2,22 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../../core/cmake/Dependencies.cmake")
 
 set(MULTIGAUGE_ESP32_LIB_DIR "${MULTIGAUGE_SOURCE_DIR}/ports/esp32/lib")
 
+function(multigauge_write_platformio_library_json library_dir library_name)
+  file(MAKE_DIRECTORY "${library_dir}")
+  file(WRITE "${library_dir}/library.json" [=[
+{
+  "name": "@library_name@",
+  "build": {
+    "srcDir": "src",
+    "includeDir": "src"
+  }
+}
+]=])
+  file(READ "${library_dir}/library.json" library_json)
+  string(REPLACE "@library_name@" "${library_name}" library_json "${library_json}")
+  file(WRITE "${library_dir}/library.json" "${library_json}")
+endfunction()
+
 function(multigauge_apply_espasyncwebserver_platformio_metadata library_dir)
   set(library_json "${library_dir}/library.json")
   set(override_template "${MULTIGAUGE_SOURCE_DIR}/ports/esp32/platformio-overrides/ESPAsyncWebServer.library.json.in")
@@ -15,6 +31,18 @@ endfunction()
 
 function(multigauge_bootstrap_esp32_dependencies)
   file(MAKE_DIRECTORY "${MULTIGAUGE_DEPS_DIR}")
+
+  set(yoga_library_dir "${MULTIGAUGE_ESP32_LIB_DIR}/multigauge-yoga")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_YOGA_DIR}/yoga" "${yoga_library_dir}/src/yoga")
+  multigauge_write_platformio_library_json("${yoga_library_dir}" "multigauge-yoga")
+
+  set(lodepng_library_dir "${MULTIGAUGE_ESP32_LIB_DIR}/multigauge-lodepng")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_LODEPNG_DIR}" "${lodepng_library_dir}/src")
+  multigauge_write_platformio_library_json("${lodepng_library_dir}" "multigauge-lodepng")
+
+  set(tjpgd_library_dir "${MULTIGAUGE_ESP32_LIB_DIR}/multigauge-tjpgd")
+  multigauge_copy_or_link_directory("${MULTIGAUGE_DEP_TJPGD_DIR}" "${tjpgd_library_dir}/src")
+  multigauge_write_platformio_library_json("${tjpgd_library_dir}" "multigauge-tjpgd")
 
   multigauge_clone_dependency(ASYNCTCP)
 

--- a/ports/esp32/platformio-overrides/ESPAsyncWebServer.library.json.in
+++ b/ports/esp32/platformio-overrides/ESPAsyncWebServer.library.json.in
@@ -1,0 +1,28 @@
+{
+  "name": "ESPAsyncWebServer",
+  "version": "@MULTIGAUGE_DEP_ESPASYNCWEBSERVER_VERSION@",
+  "description": "Asynchronous HTTP and WebSocket Server Library for ESP32.",
+  "keywords": "http,async,websocket,webserver",
+  "homepage": "https://github.com/ESP32Async/ESPAsyncWebServer",
+  "repository": {
+    "type": "git",
+    "url": "@MULTIGAUGE_DEP_ESPASYNCWEBSERVER_URL@"
+  },
+  "authors": {
+    "name": "ESP32Async",
+    "maintainer": true
+  },
+  "license": "LGPL-3.0",
+  "frameworks": "arduino",
+  "platforms": "espressif32",
+  "export": {
+    "include": [
+      "examples",
+      "src",
+      "library.json",
+      "library.properties",
+      "LICENSE",
+      "README.md"
+    ]
+  }
+}

--- a/ports/esp32/platformio.ini
+++ b/ports/esp32/platformio.ini
@@ -20,5 +20,14 @@ lib_ignore =
   ESPAsyncTCP
   AsyncTCP_RP2040W
 build_unflags = -std=gnu++11
-build_flags = -std=gnu++17
+build_flags =
+  -std=gnu++17
+  -I../../.deps/rapidjson/include
+  -I../../.deps/lodepng
+  -I../../.deps/tjpgd
+  -I../../.deps/yoga
+lib_deps =
+  multigauge-yoga
+  multigauge-lodepng
+  multigauge-tjpgd
 extra_scripts = pre:bootstrap-deps.py

--- a/ports/esp32/platformio.ini
+++ b/ports/esp32/platformio.ini
@@ -21,4 +21,4 @@ lib_ignore =
   AsyncTCP_RP2040W
 build_unflags = -std=gnu++11
 build_flags = -std=gnu++17
-extra_scripts = pre:../../scripts/bootstrap-deps.py
+extra_scripts = pre:bootstrap-deps.py

--- a/ports/esp32/platformio.ini
+++ b/ports/esp32/platformio.ini
@@ -16,6 +16,9 @@ board_build.filesystem = littlefs
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 test_build_src = true
+lib_ignore =
+  ESPAsyncTCP
+  AsyncTCP_RP2040W
 build_unflags = -std=gnu++11
 build_flags = -std=gnu++17
 extra_scripts = pre:../../scripts/bootstrap-deps.py

--- a/ports/web/CMakeLists.txt
+++ b/ports/web/CMakeLists.txt
@@ -4,8 +4,6 @@ project(multigauge_web LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/MultigaugeDependencies.cmake")
-
 if(NOT EMSCRIPTEN)
   message(FATAL_ERROR
     "multigauge_web requires the Emscripten toolchain.\n"


### PR DESCRIPTION
##  What changed?

- split shared dependency metadata from core and ESP32-specific bootstrap steps
- move PlatformIO bootstrap handling into the ESP32 port
- generate ESP32 local PlatformIO libraries for yoga, lodepng, and tjpgd
- explicitly link those generated libraries in `platformio.ini`
- ignore conflicting async TCP libraries and override ESPAsyncWebServer metadata for ESP32 builds
- remove legacy core/lib and copied-header compatibility paths

## Why?

Firmware CI was failing at link time with unresolved Yoga and lodepng symbols because PlatformIO was compiling `multigauge-core` without reliably linking the generated local dependency libraries.

## Checklist

- [X] This PR is limited to one logical feature or change
- [X] Public APIs, configuration, or documentation were updated if needed.
- [X] No debugging code, temporary files, or unrelated changes are included
- [X] CI passes.