### PR TITLE
Refactor Time Interface

### DIFF
--- a/include/multigauge/gauge/Element.h
+++ b/include/multigauge/gauge/Element.h
@@ -13,6 +13,7 @@
 #include <multigauge/gauge/Layout.h>
 
 #include <cstdint>
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -56,7 +57,7 @@ class Element : public ::mg::PropertyObject {
 
         virtual bool init(AssetManager& assetManager, GraphicsContext& context) { return true; }
         virtual void draw(Graphics& g) const {}
-        virtual void update(int deltaTime) {}
+        virtual void update(std::chrono::microseconds delta) {}
 
     public:
         enum Type { Base, Circular };
@@ -90,7 +91,7 @@ class Element : public ::mg::PropertyObject {
 
         bool initRecursive(AssetManager& assetManager, GraphicsContext& context);
         void drawRecursive(Graphics& g) const;
-        void updateRecursive(int deltaTime);
+        void updateRecursive(std::chrono::microseconds delta);
 
         //----------[ LAYOUT ]----------//
         

--- a/include/multigauge/gauge/GaugeFace.h
+++ b/include/multigauge/gauge/GaugeFace.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <chrono>
 #include <type_traits>
 #include <multigauge/graphics/colors/Color.h>
 #include <multigauge/gauge/Element.h>
@@ -39,7 +40,7 @@ class GaugeFace : public ::mg::PropertyObject {
         //----------[ LIFETIME ]----------//
 
         bool init(AssetManager& assetManager, GraphicsContext& context);
-        void update(int deltaTime);
+        void update(std::chrono::microseconds delta);
         void draw(Graphics& g) const;
 
         //----------[ CHILDREN ]----------//

--- a/include/multigauge/gauge/elements/Graph.h
+++ b/include/multigauge/gauge/elements/Graph.h
@@ -4,6 +4,9 @@
 #include <multigauge/value/ValueView.h>
 #include <multigauge/utils/Math.h>
 
+#include <chrono>
+#include <cstdint>
+
 namespace mg::gauge {
 
 using ::mg::ValueView;
@@ -14,7 +17,7 @@ using ::mg::utils::mapf;
 
 struct TimeValue {
     float value;
-    unsigned long time;
+    std::uint64_t time;
 };
 
 class Graph : public Element {
@@ -33,6 +36,7 @@ class Graph : public Element {
 
         ValueView value;
         std::vector<TimeValue> valueMemory = {};
+        std::chrono::microseconds elapsed{};
 
         enum Style { Line, Bars, Dots };
 
@@ -49,12 +53,13 @@ class Graph : public Element {
     MG_PROP(value, "value", "Value", "Value to display.")
         MG_PROPS_END()
 
-        unsigned long timeAtX(int x, int left, int width, unsigned long currentTime, float windowMs) const {
+        std::uint64_t timeAtX(int x, int left, int width, std::uint64_t currentTime, float windowMs) const {
             float t01 = float(x - left) / float(std::max(1, width)); // 0..1
-            return currentTime - (unsigned long)std::lround((1.0f - t01) * windowMs) - (unsigned long)bufferMilliseconds;
+            const std::uint64_t offset = static_cast<std::uint64_t>(std::lround((1.0f - t01) * windowMs)) + static_cast<std::uint64_t>(std::max(0, bufferMilliseconds));
+            return currentTime > offset ? currentTime - offset : 0;
         }
 
-        float valueAtTime(unsigned long time) const {
+        float valueAtTime(std::uint64_t time) const {
             if (valueMemory.empty()) return 0.0f;
             if (valueMemory.size() == 1) return valueMemory[0].value;
 
@@ -70,7 +75,7 @@ class Graph : public Element {
                 const TimeValue& b = valueMemory[i + 1]; // older
 
                 if (a.time >= time && time >= b.time) {
-                    const unsigned long dt = a.time - b.time;
+                    const std::uint64_t dt = a.time - b.time;
                     if (dt == 0) return a.value;
 
                     const float t = float(a.time - time) / float(dt);
@@ -87,10 +92,12 @@ class Graph : public Element {
         void draw(Graphics& g) const override {
             const auto b = getBounds();
 
+            if (seconds <= 0.0f || samplePx <= 0) return;
+
             const float minimum = value.minimumBase();
             const float maximum = value.maximumBase();
 
-            const unsigned long currentTime = 0; //millis(); // TODO HANGE TO ABSTRACT TIME CLASS
+            const std::uint64_t currentTime = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
             const float secondLength = b.width / seconds; // length of 1 second
 
             if (backgroundColor) {
@@ -115,7 +122,7 @@ class Graph : public Element {
                         int prevX = 0, prevY = 0;
 
                         for (int x = b.getLeft(); x <= b.getRight(); x += samplePx) {
-                            const unsigned long t = timeAtX(x, b.getLeft(), b.width, currentTime, windowMs);
+                            const std::uint64_t t = timeAtX(x, b.getLeft(), b.width, currentTime, windowMs);
                             const float v = valueAtTime(t);
                             const int y = mapf(v, minimum, maximum, b.getBottom(), b.getTop());
 
@@ -141,7 +148,7 @@ class Graph : public Element {
                         const float windowMs = seconds * 1000.0f;
 
                         for (int x = b.getLeft(); x <= b.getRight(); x += samplePx) {
-                            const unsigned long t = timeAtX(x, b.getLeft(), b.width, currentTime, windowMs);
+                            const std::uint64_t t = timeAtX(x, b.getLeft(), b.width, currentTime, windowMs);
                             const float v = valueAtTime(t);
                             const int yVal = mapf(v, minimum, maximum, b.getBottom(), b.getTop());
 
@@ -158,7 +165,7 @@ class Graph : public Element {
                         const float windowMs = seconds * 1000.0f;
 
                         for (int x = b.getLeft(); x <= b.getRight(); x += samplePx) {
-                            const unsigned long t = timeAtX(x, b.getLeft(), b.width, currentTime, windowMs);
+                            const std::uint64_t t = timeAtX(x, b.getLeft(), b.width, currentTime, windowMs);
                             const float v = valueAtTime(t);
                             const int y = mapf(v, minimum, maximum, b.getBottom(), b.getTop());
 
@@ -199,8 +206,9 @@ class Graph : public Element {
             }
         }
 
-        void update(int deltaTime) override {
-            unsigned long currentTime = 0; //millis(); // TODO: CHANGE TO ABSTRACT TIME CLASS
+        void update(std::chrono::microseconds delta) override {
+            elapsed += delta;
+            const std::uint64_t currentTime = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
 
             valueMemory.insert(valueMemory.begin(), {value.valueBase(), currentTime});
 

--- a/include/multigauge/gauge/elements/Horizon.h
+++ b/include/multigauge/gauge/elements/Horizon.h
@@ -113,7 +113,7 @@ class Horizon : public Element {
             }
         }
 
-        void update(int deltaTime) override {
+        void update(std::chrono::microseconds delta) override {
             zPosition += 0; //lateralAcceleration.getValueRaw() * zVelMultiplier; //zValue.getValue(DEFAULT) * zVelMultiplier;
             xPosition -= 0.01f; //speed.getValueRaw() * xVelMultiplier; //xValue.getValue(DEFAULT) * xVelMultiplier;
         }

--- a/include/multigauge/gauge/elements/circular/CircularScale.h
+++ b/include/multigauge/gauge/elements/circular/CircularScale.h
@@ -26,7 +26,7 @@ class CircularScale : public CircularElement {
 
         void draw(Graphics& g) const override;
 
-        void update(int deltaTime) override;
+        void update(std::chrono::microseconds delta) override;
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/graphics/colors/TimeColor.h
+++ b/include/multigauge/graphics/colors/TimeColor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+
 #include <multigauge/graphics/colors/Color.h>
 #include <multigauge/graphics/colors/ColorTimeline.h>
 
@@ -21,6 +23,7 @@ class TimeColor : public Color {
         };
 
     private:
+        static std::chrono::microseconds currentElapsed;
         ColorTimeline timeline;
         LoopType loopType;
 
@@ -36,6 +39,8 @@ class TimeColor : public Color {
         float getTime() const;
 
     public:
+        /// Updates the shared monotonic runtime time used by all time colors.
+        static void setElapsed(std::chrono::microseconds elapsed) noexcept;
         /// @brief Constructs a TimeColor with the default timeline and loop type.
         TimeColor();
 

--- a/include/multigauge/io/Time.h
+++ b/include/multigauge/io/Time.h
@@ -1,14 +1,15 @@
 #pragma once
 
-#include <cstdint>
+#include <chrono>
 
 namespace mg::io {
 
 class Time {
     public:
         virtual ~Time() = default;
-        virtual uint64_t getMillis() = 0;
-        virtual uint64_t getMicros() = 0;
+
+        /// Monotonic elapsed time; the epoch is intentionally unspecified.
+        virtual std::chrono::microseconds elapsed() const = 0;
 };
 
 } // namespace mg::io

--- a/include/multigauge/runtime/RuntimeContext.h
+++ b/include/multigauge/runtime/RuntimeContext.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <chrono>
 #include <memory>
 
 #include <multigauge/graphics/Graphics.h>
@@ -50,7 +50,7 @@ class RuntimeContext {
         Screen* getScreen();
         const Screen* getScreen() const;
 
-        void frame(uint64_t deltaUs);
+        void frame(std::chrono::microseconds delta);
 };
 
 }

--- a/include/multigauge/screens/EditorScreen.h
+++ b/include/multigauge/screens/EditorScreen.h
@@ -22,7 +22,7 @@ class EditorScreen : public Screen {
 
         void onShow(RuntimeContext& ctx) override;
         void onHide(RuntimeContext& ctx) override;
-        void update(RuntimeContext& ctx, uint64_t deltaUs) override;
+        void update(RuntimeContext& ctx, std::chrono::microseconds delta) override;
         void draw(RuntimeContext& ctx, graphics::Graphics& g) override;
 };
 

--- a/include/multigauge/screens/GaugeScreen.h
+++ b/include/multigauge/screens/GaugeScreen.h
@@ -20,7 +20,7 @@ class GaugeScreen : public Screen {
 
         void onShow(RuntimeContext& ctx) override;
         void onHide(RuntimeContext& ctx) override;
-        void update(RuntimeContext& ctx, uint64_t deltaUs) override;
+        void update(RuntimeContext& ctx, std::chrono::microseconds delta) override;
         void draw(RuntimeContext& ctx, graphics::Graphics& g) override;
 };
 

--- a/include/multigauge/screens/Screen.h
+++ b/include/multigauge/screens/Screen.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+
 #include <multigauge/runtime/RuntimeContext.h>
 
 namespace mg {
@@ -11,7 +13,7 @@ class Screen {
         virtual void onShow(RuntimeContext& context) {};
         virtual void onHide(RuntimeContext& context) {};
 
-        virtual void update(RuntimeContext& context, uint64_t deltaUs) = 0;
+        virtual void update(RuntimeContext& context, std::chrono::microseconds delta) = 0;
         virtual void draw(RuntimeContext& context, graphics::Graphics& g) = 0;
 };
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -8,12 +8,14 @@
 #include <multigauge/HandlePool.h>
 #include <multigauge/editor/Api.h>
 #include <multigauge/gauge/GaugeFace.h>
+#include <multigauge/graphics/colors/TimeColor.h>
 #include <multigauge/screens/GaugeScreen.h>
 #include <multigauge/screens/EditorScreen.h>
 #include <multigauge/io/Log.h>
 #include <multigauge/utils/Json.h>
 
 #include <utility>
+#include <chrono>
 
 namespace mg {
 
@@ -29,7 +31,7 @@ namespace {
 
     HandlePool<RuntimeContext> contexts;
     bool initialized = false;
-    uint64_t lastUs = 0;
+    std::chrono::microseconds lastElapsed{};
     YGConfigRef yogaConfig = nullptr;
 
     io::FileSystem* g_fs = nullptr;
@@ -58,7 +60,7 @@ bool init(io::FileSystem& fs, io::Time& time, const AppConfig& config, io::Logge
     yogaConfig = createYogaConfig();
     initialized = true;
 
-    lastUs = g_time->getMicros();
+    lastElapsed = g_time->elapsed();
 
     return true;
 }
@@ -71,17 +73,20 @@ void shutdown() {
         yogaConfig = nullptr;
     }
     initialized = false;
-    lastUs = 0;
+    lastElapsed = {};
+    g_time = nullptr;
+    g_fs = nullptr;
 }
 
 void frame() {
     if (!initialized) return;
 
-    const uint64_t nowUs = g_time->getMicros();
-    const uint64_t deltaUs = nowUs - lastUs;
-    lastUs = nowUs;
+    const std::chrono::microseconds now = g_time->elapsed();
+    const std::chrono::microseconds delta = now >= lastElapsed ? now - lastElapsed : std::chrono::microseconds{};
+    lastElapsed = now;
 
-    for (auto& context : contexts) context.frame(deltaUs);
+    graphics::TimeColor::setElapsed(now);
+    for (auto& context : contexts) context.frame(delta);
 }
 
 YGConfigRef getYogaConfig() { return yogaConfig; }

--- a/src/gauge/Element.cpp
+++ b/src/gauge/Element.cpp
@@ -148,9 +148,9 @@ void Element::drawRecursive(Graphics &g) const {
     for (auto const& c : children) c->drawRecursive(g);
 }
 
-void Element::updateRecursive(int deltaTime) {
-    update(deltaTime);
-    for (auto& c : children) c->updateRecursive(deltaTime);
+void Element::updateRecursive(std::chrono::microseconds delta) {
+    update(delta);
+    for (auto& c : children) c->updateRecursive(delta);
 }
 
 void Element::layoutRecursive(float parentAbsX, float parentAbsY) {

--- a/src/gauge/GaugeFace.cpp
+++ b/src/gauge/GaugeFace.cpp
@@ -62,8 +62,8 @@ bool GaugeFace::init(AssetManager& assetManager, GraphicsContext& context) {
     return ok;
 }
 
-void GaugeFace::update(int deltaTime) {
-    for (auto& c : children) c->updateRecursive(deltaTime);
+void GaugeFace::update(std::chrono::microseconds delta) {
+    for (auto& c : children) c->updateRecursive(delta);
 }
 
 void GaugeFace::draw(Graphics& g) const {

--- a/src/gauge/elements/circular/CircularScale.cpp
+++ b/src/gauge/elements/circular/CircularScale.cpp
@@ -20,7 +20,7 @@ void CircularScale::draw(Graphics &g) const {
     ticks.drawCircular(g, {cx, cy}, radius, startAngle, endAngle, value.minimumBase(), value.maximumBase());
 }
 
-void CircularScale::update(int deltaTime) {
+void CircularScale::update(std::chrono::microseconds delta) {
     ValueView value = resolvedValueView();
 
     ticks.setValueView(value.valueBase());

--- a/src/graphics/colors/TimeColor.cpp
+++ b/src/graphics/colors/TimeColor.cpp
@@ -5,12 +5,18 @@
 
 namespace mg::graphics {
 
+std::chrono::microseconds TimeColor::currentElapsed{};
+
+void TimeColor::setElapsed(std::chrono::microseconds elapsed) noexcept {
+    currentElapsed = elapsed;
+}
+
 float TimeColor::getTime() const {
     float duration = timeline.getEndPosition();
 
     if (timeline.size() == 0 || duration <= 0.0f) return 0.0f;
 
-    float t = 0; //static_cast<float>(millis()) / 1000.0f; // TODO: PUT TIME HERE!!!
+    float t = std::chrono::duration<float, std::milli>(currentElapsed).count();
 
     switch (loopType) {
         case LoopType::Forward:

--- a/src/runtime/RuntimeContext.cpp
+++ b/src/runtime/RuntimeContext.cpp
@@ -47,7 +47,7 @@ Screen* RuntimeContext::getScreen() { return screen.get(); }
 
 const Screen* RuntimeContext::getScreen() const { return screen.get(); }
 
-void RuntimeContext::frame(uint64_t deltaUs) {
+void RuntimeContext::frame(std::chrono::microseconds delta) {
     if (!context) return;
 
     graphics.clearColorCache();
@@ -56,7 +56,7 @@ void RuntimeContext::frame(uint64_t deltaUs) {
     context->beginFrame();
 
     if (screen) {
-        screen->update(*this, deltaUs);
+        screen->update(*this, delta);
         screen->draw(*this, graphics);
     } else {
         graphics.fillAll(backgroundColor);

--- a/src/screens/EditorScreen.cpp
+++ b/src/screens/EditorScreen.cpp
@@ -34,7 +34,7 @@ void EditorScreen::onHide(RuntimeContext& ctx) {
     lastFace = nullptr;
 }
 
-void EditorScreen::update(RuntimeContext& ctx, uint64_t deltaUs) {
+void EditorScreen::update(RuntimeContext& ctx, std::chrono::microseconds delta) {
     gauge::GaugeFace* face = resolveFace();
     if (!face) {
         lastFace = nullptr;
@@ -42,7 +42,7 @@ void EditorScreen::update(RuntimeContext& ctx, uint64_t deltaUs) {
     }
 
     ensureFaceInitialized(ctx, face);
-    face->update(deltaUs);
+    face->update(delta);
 }
 
 void EditorScreen::draw(RuntimeContext& ctx, graphics::Graphics& g) {

--- a/src/screens/GaugeScreen.cpp
+++ b/src/screens/GaugeScreen.cpp
@@ -17,9 +17,9 @@ void GaugeScreen::onShow(RuntimeContext& ctx) {
 
 void GaugeScreen::onHide(RuntimeContext& ctx) {}
 
-void GaugeScreen::update(RuntimeContext& ctx, uint64_t deltaUs) {
+void GaugeScreen::update(RuntimeContext& ctx, std::chrono::microseconds delta) {
     if (!face) return;
-    face->update(static_cast<int>(deltaUs));
+    face->update(delta);
 }
 
 void GaugeScreen::draw(RuntimeContext& ctx, graphics::Graphics& g) {


### PR DESCRIPTION
## What changed?

Simplified Time interface and moved to std::chrono

## Why?

more modern use of c++ with `std::chrono` and dont need separate millisecond and microsecond functions.

## Refactoring notes

- Moved all important uses of time to std::chrono.
- Time API only has `elapsed()` instead of milliseconds and microseconds.
## Checklist

* [X] This PR is limited to one logical refactor
* [X] Existing behavior is preserved unless explicitly documented
* [X] Public APIs, configuration, serialization, or documentation were updated if needed
* [X] Tests were added or updated where responsibilities or boundaries changed
* [X] No debugging code, temporary files, or unrelated changes are included