### PR TITLE
Refactor Entire Color System

### DIFF
--- a/include/multigauge/App.h
+++ b/include/multigauge/App.h
@@ -14,6 +14,7 @@
 #include <multigauge/io/FileSystem.h>
 #include <multigauge/io/Time.h>
 #include <multigauge/io/Logger.h>
+#include <multigauge/graphics/UserPalette.h>
 
 namespace mg {
 
@@ -35,6 +36,11 @@ bool init(io::FileSystem& fs, io::Time& time, const AppConfig& config = AppConfi
 void shutdown();
 void frame();
 YGConfigRef getYogaConfig();
+
+//----------[ USER PALETTE ]----------//
+
+bool setUserColor(std::size_t slot, graphics::rgba color);
+graphics::rgba getUserColor(std::size_t slot);
 
 //----------[ CONTEXT ]----------//
 

--- a/include/multigauge/gauge/ticks/TickList.h
+++ b/include/multigauge/gauge/ticks/TickList.h
@@ -21,8 +21,8 @@ namespace mg::gauge {
 using ::mg::Line;
 using ::mg::Point;
 using ::mg::graphics::Graphics;
-using ::mg::graphics::Paint;
 using ::mg::graphics::PaintTimeline;
+using ::mg::graphics::ResolvedPaint;
 using ::mg::utils::lerp;
 using ::mg::utils::inRange;
 
@@ -94,16 +94,16 @@ class TickList : public ::mg::PropertyObject {
             }
         }
 
-        void drawLineTick(Graphics& g, Line<float> line, float thickness, Paint& paint) const {
+        void drawLineTick(Graphics& g, Line<float> line, float thickness, const ResolvedPaint& paint) const {
             g.setPaint(paint);
             g.drawLine(line.toInt(), thickness);
         }
 
-        void drawCircleTick(Graphics& g, Line<float> line, float thickness, Paint& paint) const {
+        void drawCircleTick(Graphics& g, Line<float> line, float thickness, const ResolvedPaint& paint) const {
             
         }
 
-        void drawTriangleTick(Graphics& g, Line<float> line, float thickness, Paint& paint) const {
+        void drawTriangleTick(Graphics& g, Line<float> line, float thickness, const ResolvedPaint& paint) const {
             
         }
 

--- a/include/multigauge/graphics/Graphics.h
+++ b/include/multigauge/graphics/Graphics.h
@@ -10,9 +10,10 @@
 #include <multigauge/graphics/image/Image.h>
 #include <multigauge/graphics/image/NineSlice.h>
 #include <multigauge/graphics/TextPaint.h>
+#include <multigauge/graphics/colors/ColorTimeline.h>
 
 #include <string>
-#include <unordered_map>
+#include <cstddef>
 
 #define MIN_HYPHEN_PREFIX 3 // Prefix must be this number of chars or higher to be hyphenated in text wrap
 
@@ -43,13 +44,10 @@ class Graphics final {
 
         float thickness = 0.0f; // for stroke
 
-        /// @brief Cache that stores a color's value for quick lookup
-        std::unordered_map<const Color*, rgba> colorCache;
+        ColorResolver colorResolver;
+        ColorResolver::Frame colorFrame;
 
-        /// @brief Gets a color's value from the cache.
-        /// @param color The Color object to get the color value of
-        /// @return The current Color object's 16-bit color value
-        rgba getCachedColor(const Color& color);
+        rgba resolveColor(const Color& color) noexcept;
 
         //----------[ Font ]----------//
         std::string family = "default";
@@ -64,7 +62,15 @@ class Graphics final {
         /// @brief Returns the full rawable bounds of the current target (in pixels).
         Rect<int> getScreenBounds();
 
-        void clearColorCache();
+        /// Starts color resolution for one immutable render frame. Color based
+        /// drawing before this call deterministically resolves to transparent.
+        void beginFrame(const ColorFrame& frame) noexcept;
+        void endFrame() noexcept;
+        /// Reserves color-resolution storage outside rendering for packages
+        /// that use more than the default number of colors per frame.
+        void reserveColorCache(std::size_t colorCount) { colorResolver.reserve(colorCount); }
+        [[nodiscard]] rgba resolve(const Color& color) const noexcept;
+        [[nodiscard]] const ColorResolver::Frame& colorFrameToken() const noexcept { return colorFrame; }
         
         //----------[ COLOR ]----------//
 
@@ -86,6 +92,7 @@ class Graphics final {
         void setPaint(const Color* fill = nullptr, const Color* stroke = nullptr, float thickness = 1.0f);
         /// @brief Sets the current fill and stroke colors and stroke thickness (in pixels).
         void setPaint(const Paint& paint);
+        void setPaint(const ResolvedPaint& paint);
 
         //----------[ FILL ]----------//
 

--- a/include/multigauge/graphics/UserPalette.h
+++ b/include/multigauge/graphics/UserPalette.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+#include <multigauge/graphics/colors/rgba.h>
+
+namespace mg::graphics {
+
+/// Persistent user preference colors shared by every runtime context.
+/// Palette updates must occur outside drawing; UserColor definitions only store
+/// an index into this palette.
+class UserPalette {
+public:
+    static constexpr std::size_t Size = 3;
+
+    [[nodiscard]] rgba color(std::size_t index, rgba fallback = rgba{0, 0, 0, 0}) const noexcept {
+        return index < colors_.size() ? colors_[index] : fallback;
+    }
+
+    bool setColor(std::size_t index, rgba color) noexcept {
+        if (index >= colors_.size()) return false;
+        colors_[index] = color;
+        return true;
+    }
+
+private:
+    std::array<rgba, Size> colors_{
+        rgba{255, 255, 255, 255},
+        rgba{255, 0, 0, 255},
+        rgba{0, 0, 0, 255},
+    };
+};
+
+} // namespace mg::graphics

--- a/include/multigauge/graphics/colors/Color.h
+++ b/include/multigauge/graphics/colors/Color.h
@@ -1,101 +1,49 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
-
+#include <multigauge/graphics/colors/ColorResolver.h>
 #include <multigauge/graphics/colors/rgba.h>
 #include <multigauge/properties/PropertyObject.h>
 
-#define DEFAULT_COLOR { 0, 0, 0, 255}
+#define DEFAULT_COLOR { 0, 0, 0, 255 }
 
 namespace mg::graphics {
 
-class Color;              // forward declare
-class ColorTimeline;      // forward declare
-
+class Color;
 using OwnedColor = std::unique_ptr<Color>;
 
+/// Immutable-at-render-time color definition. The property system may mutate a
+/// definition between frames; a ColorResolver snapshots every dynamic input for
+/// the duration of one frame.
 class Color : public ::mg::PropertyObject {
     MG_EDITOR_NAME("Color")
-    public:
-        virtual ~Color() = default;
 
-        MG_POLYMORPHIC_REGISTRY(OwnedColor)
-        
-        /// @brief Creates a clone of this Color object
-        /// @return A unique pointer to the created Color object
-        virtual OwnedColor clone() const = 0;
+public:
+    virtual ~Color() = default;
+    MG_POLYMORPHIC_REGISTRY(OwnedColor)
 
-        /// @brief Gets the current color value.
-        /// @return The 16-bit color value
-        virtual rgba getColor() const = 0;
+    virtual OwnedColor clone() const = 0;
 
-        /// @brief Gets the color timeline if this color type has one.
-        /// @return Pointer to ColorTimeline, or nullptr if this color has no timeline
-        virtual const ColorTimeline* getTimeline() const;
+    Color(const Color&) noexcept;
+    Color& operator=(const Color&) noexcept { return *this; }
+    [[nodiscard]] std::uint32_t id() const noexcept { return id_; }
 
-        /// @brief Color type identifiers
-        enum class Type { Static, Value, Time, User };
+protected:
+    Color() noexcept;
+    /// Implementations must resolve nested definitions through `frame` and
+    /// return transparent black for invalid/missing inputs.
+    virtual rgba resolveUncached(const ColorResolver::Frame& frame) const noexcept = 0;
 
-        /// @brief Gets the type of this color.
-        /// @return The Type enum value
-        virtual Type getType() const = 0;
-
-        //----------[ BLENDING ]----------//
-        
-        /// @brief Blends this color with a static color value.
-        /// @param color The 16-bit color value to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new Color object with the blended result
-        virtual OwnedColor blended(rgba color, float alpha) const = 0;
-
-        /// @brief Blends this color with another Color object.
-        /// @param color The Color object to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = other color)
-        /// @return A new Color object with the blended result
-        virtual OwnedColor blended(const Color& color, float alpha) const = 0;
+private:
+    friend class ColorResolver;
+    std::uint32_t id_;
 };
-
-} // namespace mg::graphics
-
-namespace mg {
-
-template <>
-struct MgPropWidgetTraits<graphics::OwnedColor> { static constexpr const char* value = "color"; };
-
-template <>
-struct MgPropNullableTraits<graphics::OwnedColor> { static constexpr bool value = true; };
-
-template <>
-struct MgPolymorphicRegistryTraits<graphics::OwnedColor> {
-    static constexpr bool supported = true;
-
-    static bool getTypesMeta(json::Writer& writer) {
-        return graphics::Color::registry().writeTypesMeta(writer);
-    }
-};
-
-template <>
-struct PolymorphicOwnedTraits<graphics::OwnedColor> {
-    static constexpr bool supported = true;
-    using Base = graphics::Color;
-};
-
-CODEC_BEGIN(graphics::OwnedColor)
-    DECODE();
-
-    ENCODE();
-CODEC_END()
-
-} // namespace mg
-
-namespace mg::graphics {
-
-//----------[ FILL STROKE ]----------//
 
 struct Paint : public ::mg::PropertyObject {
     MG_EDITOR_NAME("Paint")
-    
+
     OwnedColor fill;
     OwnedColor stroke;
     float thickness = 1.0f;
@@ -107,12 +55,24 @@ struct Paint : public ::mg::PropertyObject {
     MG_PROPS_END()
 
     Paint();
-
     Paint(OwnedColor fill, OwnedColor stroke, float thickness = 1.0f);
-
-    Paint blended(rgba color, float alpha) const;
-    Paint blended(const Color& color, float alpha) const;
-    Paint blended(const Paint& other, float alpha) const;
 };
 
 } // namespace mg::graphics
+
+namespace mg {
+
+template <> struct MgPropWidgetTraits<graphics::OwnedColor> { static constexpr const char* value = "color"; };
+template <> struct MgPropNullableTraits<graphics::OwnedColor> { static constexpr bool value = true; };
+
+template <> struct MgPolymorphicRegistryTraits<graphics::OwnedColor> {
+    static constexpr bool supported = true;
+    static bool getTypesMeta(json::Writer& writer) { return graphics::Color::registry().writeTypesMeta(writer); }
+};
+
+CODEC_BEGIN(graphics::OwnedColor)
+    DECODE();
+    ENCODE();
+CODEC_END()
+
+} // namespace mg

--- a/include/multigauge/graphics/colors/ColorFrame.h
+++ b/include/multigauge/graphics/colors/ColorFrame.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <chrono>
+#include <vector>
+
+#include <multigauge/graphics/UserPalette.h>
+#include <multigauge/value/Value.h>
+
+namespace mg {
+class Value;
+}
+
+namespace mg::graphics {
+
+/// A frame-stable, index-addressable copy of the registered values.
+/// The Value registry is contiguous and static, so a Value* can be converted to
+/// an index without an identifier lookup while drawing.
+class ValueSnapshot {
+public:
+    void refresh() noexcept;
+    [[nodiscard]] float value(const ::mg::Value* value, float fallback = 0.0F) const noexcept;
+
+private:
+    const ::mg::Value* first_ = nullptr;
+    std::vector<float> values_;
+};
+
+/// Frame-snapshotted color inputs. The user palette is a stable application
+/// preference reference and, by contract, is only changed between frames.
+class ColorFrame {
+public:
+    void refresh(std::chrono::microseconds elapsed, const UserPalette& palette) noexcept;
+
+    [[nodiscard]] std::chrono::microseconds elapsed() const noexcept { return elapsed_; }
+    [[nodiscard]] const ValueSnapshot& values() const noexcept { return values_; }
+    [[nodiscard]] const UserPalette* palette() const noexcept { return palette_; }
+
+private:
+    std::chrono::microseconds elapsed_{};
+    ValueSnapshot values_;
+    const UserPalette* palette_ = nullptr;
+};
+
+} // namespace mg::graphics

--- a/include/multigauge/graphics/colors/ColorResolver.h
+++ b/include/multigauge/graphics/colors/ColorResolver.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <multigauge/graphics/colors/ColorFrame.h>
+
+namespace mg::graphics {
+
+class Color;
+
+/// Resolves immutable Color definitions against one explicit ColorFrame.
+/// A Frame token becomes invalid as soon as the resolver begins another frame.
+class ColorResolver {
+public:
+    /// `capacity` is the maximum number of distinct color definitions that can
+    /// be resolved in one frame without a fallback. Storage is allocated here,
+    /// never by resolve().
+    explicit ColorResolver(std::size_t capacity = 64);
+
+    class Frame {
+    public:
+        Frame() = default;
+        [[nodiscard]] bool valid() const noexcept;
+        [[nodiscard]] const ColorFrame* data() const noexcept;
+        [[nodiscard]] rgba resolve(const Color& color) const noexcept;
+
+    private:
+        friend class ColorResolver;
+        Frame(ColorResolver* resolver, std::uint64_t generation) noexcept : resolver_(resolver), generation_(generation) {}
+
+        ColorResolver* resolver_ = nullptr;
+        std::uint64_t generation_ = 0;
+    };
+
+    [[nodiscard]] Frame beginFrame(const ColorFrame& frame) noexcept;
+    /// Call outside rendering when a package needs a larger per-frame budget.
+    void reserve(std::size_t colorCount) { cache_.reserve(colorCount); }
+
+private:
+    enum class State : std::uint8_t { Resolving, Resolved };
+    struct CacheEntry {
+        std::uint32_t id = 0;
+        const Color* color = nullptr;
+        std::uint64_t generation = 0;
+        State state = State::Resolved;
+        rgba value{};
+    };
+
+    [[nodiscard]] rgba resolve(const Frame& frame, const Color& color) noexcept;
+
+    const ColorFrame* frame_ = nullptr;
+    std::uint64_t generation_ = 0;
+    std::vector<CacheEntry> cache_;
+};
+
+} // namespace mg::graphics

--- a/include/multigauge/graphics/colors/ColorTimeline.h
+++ b/include/multigauge/graphics/colors/ColorTimeline.h
@@ -1,181 +1,89 @@
 #pragma once
 
-#include <multigauge/graphics/colors/Color.h>
-
 #include <cstddef>
 #include <vector>
-#include <utility>
+
+#include <multigauge/graphics/colors/Color.h>
 
 namespace mg::graphics {
-
-//----------[ KEYFRAME ]----------//
 
 struct ColorKeyframe : public ::mg::PropertyObject {
     MG_EDITOR_NAME("Gradient Stop")
 
-    /// @brief Position in the timeline
-    float position = 0;
-    /// @brief The color at this position
-    OwnedColor color = nullptr;
+    float position = 0.0F; // normalized [0, 1]
+    OwnedColor color;
 
     MG_PROPS_BEGIN()
-    MG_PROP(position, "pos", "Position", "Position of the gradient stop")
-    MG_PROP(color, "color", "Color", "Color of the gradient stop.")
+    MG_PROP(position, "pos", "Position", "Normalized gradient stop position.")
+    MG_PROP(color, "color", "Color", "Color at this stop.")
     MG_PROPS_END()
 
-    ColorKeyframe();
-    
+    ColorKeyframe() = default;
     ColorKeyframe(OwnedColor color, float position);
-
     ColorKeyframe(const ColorKeyframe& other);
-
     ColorKeyframe& operator=(const ColorKeyframe& other);
-
-    ColorKeyframe(ColorKeyframe&&) = default;
-    
-    ColorKeyframe& operator=(ColorKeyframe&&) = default;
+    ColorKeyframe(ColorKeyframe&&) noexcept = default;
+    ColorKeyframe& operator=(ColorKeyframe&&) noexcept = default;
 };
 
-//----------[ TIMELINE ]----------//
-
+/// A normalized color ramp. Position mapping belongs to ValueColor/TimeColor;
+/// interpolation always happens in this fixed [0, 1] domain.
 class ColorTimeline : public ::mg::PropertyObject {
     MG_EDITOR_NAME("Gradient")
     CODEC_FRIEND(ColorTimeline)
-    
-    private:
-        std::vector<ColorKeyframe> keyframes;
 
-        MG_PROPS_BEGIN()
-    MG_PROP(keyframes, "keyframes", "Stops", "Gradient color stops.")
-        MG_PROPS_END()
+    std::vector<ColorKeyframe> keyframes;
+    MG_PROPS_BEGIN()
+    MG_PROP(keyframes, "keyframes", "Stops", "Normalized gradient stops.")
+    MG_PROPS_END()
 
-        /// @brief Finds the index of the keyframe at or before the given position.
-        /// @param position The position to search for
-        /// @return The index of the keyframe
-        size_t getKeyframeIndexAtPosition(float position) const;
+public:
+    ColorTimeline() = default;
+    explicit ColorTimeline(rgba color);
+    explicit ColorTimeline(OwnedColor color);
+    ColorTimeline(const ColorTimeline& other);
+    ColorTimeline& operator=(const ColorTimeline& other);
+    ColorTimeline(ColorTimeline&&) noexcept = default;
+    ColorTimeline& operator=(ColorTimeline&&) noexcept = default;
 
-    public:
-        ColorTimeline();
+    void clear();
+    bool addKeyframe(rgba color, float position);
+    bool addKeyframe(OwnedColor color, float position);
+    bool addKeyframe(ColorKeyframe keyframe);
 
-        ColorTimeline(rgba color);
+    [[nodiscard]] std::size_t size() const noexcept;
+    [[nodiscard]] bool empty() const noexcept;
+    [[nodiscard]] bool valid() const noexcept;
+    [[nodiscard]] rgba sample(float normalizedPosition, const ColorResolver::Frame& frame) const noexcept;
 
-        ColorTimeline(OwnedColor color);
-
-        ColorTimeline(const ColorTimeline& other);
-
-        ColorTimeline& operator=(const ColorTimeline& other);
-
-        ColorTimeline(ColorTimeline&&) = default;
-
-        ColorTimeline& operator=(ColorTimeline&&) = default;
-
-        //----------[ MUTATION ]----------//
-
-        /// @brief Removes all keyframes from the timeline
-        void clear();
-
-        /// @brief Adds a StaticColor color keyframe to the timeline
-        /// @param color The 16-bit color value
-        /// @param position The position in the timeline
-        void addKeyframe(rgba color, float position);
-
-        /// @brief Adds a color keyframe to the timeline.
-        /// @param color The color object for this keyframe
-        /// @param position The position in the timeline
-        void addKeyframe(OwnedColor color, float position);
-
-        /// @brief Adds a color keyframe to the timeline.
-        /// @param keyframe The ColorKeyframe to add
-        void addKeyframe(ColorKeyframe keyframe);
-
-        //----------[ QUERIES ]----------//
-
-        /// @brief Gets the number of keyframes in the timeline.
-        /// @return The number of keyframes
-        size_t size() const;
-
-        bool empty() const;
-
-        /// @brief Gets the position of the first keyframe.
-        /// @return The start position, or 0.0 if timeline is empty
-        float getStartPosition() const;
-
-        /// @brief Gets the position of the last keyframe.
-        /// @return The start position, or 0.0 if timeline is empty
-        float getEndPosition() const;
-
-        //----------[ COLOR ]----------//
-
-        /// @brief Gets the interpolated color at a specific position.
-        /// @param position The position in the timeline
-        /// @return The 16-bit color value at that position
-        rgba getColor(float position) const;
-
-        /// @brief Samples the timeline at regular intervals.
-        /// @param startPosition The starting position for sampling
-        /// @param endPosition The ending position for sampling
-        /// @param numSamples The number of samples to take
-        /// @return Vector of 16-bit color values
-        std::vector<rgba> sample(float startPosition, float endPosition, size_t numSamples);
-
-        //----------[ BLENDING ]----------//
-
-        /// @brief Blends this timeline with a static color value.
-        /// @param color The 16-bit color value to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new ColorTimeline object with the blended result
-        ColorTimeline blended(rgba color, float alpha) const;
-
-        /// @brief Blends this timeline with another Color object.
-        /// @param other The Color object to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new ColorTimeline object with the blended result
-        ColorTimeline blended(const Color& other, float alpha) const;
-
-        /// @brief Blends this timeline with another ColorTImeline object.
-        /// @param other The ColorTImeline object to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new ColorTimeline object with the blended result
-        ColorTimeline blended(const ColorTimeline& other, float alpha) const;
-
-        //----------[ UTILS ]----------//
-        
-        /// @brief Gets all keyframe positions in the timeline.
-        /// @return Vector of all position values
-        std::vector<float> getPositions() const;
-
-        /// @brief Gets keyframe positions remapped to a new range
-        /// @param start The new start position
-        /// @param end The new end position
-        /// @return Vector of remapped position values
-        std::vector<float> getPositionsMapped(float start = 0.0f, float end = 1.0f) const;
+private:
+    [[nodiscard]] std::size_t indexAt(float normalizedPosition) const noexcept;
 };
 
-//----------[ FILL STROKE TIMELINE ]----------//
+using ColorRamp = ColorTimeline;
+
+struct ResolvedPaint {
+    bool fillEnabled = false;
+    rgba fill{};
+    bool strokeEnabled = false;
+    rgba stroke{};
+    float thickness = 1.0F;
+};
 
 struct PaintTimeline : public ::mg::PropertyObject {
     ColorTimeline fill;
     ColorTimeline stroke;
-    float thickness = 1.0f;
+    float thickness = 1.0F;
 
     MG_PROPS_BEGIN()
-    MG_PROP(fill, "fill", "Fill", "Fill color.")
-    MG_PROP(stroke, "stroke", "Stroke", "Stroke color.")
-    MG_PROP(thickness, "thickness", "Thickness", "Thickness of the stroke.")
+    MG_PROP(fill, "fill", "Fill", "Fill gradient.")
+    MG_PROP(stroke, "stroke", "Stroke", "Stroke gradient.")
+    MG_PROP(thickness, "thickness", "Thickness", "Stroke thickness.")
     MG_PROPS_END()
 
     PaintTimeline() = default;
-
     PaintTimeline(ColorTimeline fill, ColorTimeline stroke, float thickness);
-
-    //----------[ BLENDING ]----------//
-
-    PaintTimeline blended(rgba color, float alpha) const;
-    PaintTimeline blended(const Color& color, float alpha) const;
-    PaintTimeline blended(const ColorTimeline& color, float alpha) const;
-    PaintTimeline blended(const PaintTimeline& other, float alpha) const;
-
-    Paint getPaintAtPosition(float position) const;
+    [[nodiscard]] ResolvedPaint sample(float normalizedPosition, const ColorResolver::Frame& frame) const noexcept;
 };
 
 } // namespace mg::graphics
@@ -184,23 +92,31 @@ namespace mg {
 
 CODEC_BEGIN(graphics::ColorTimeline)
     DECODE() {
-        graphics::OwnedColor color;
-        if (decodeAny(v, color)) {
-            out = graphics::ColorTimeline(std::move(color));
-            return true;
+        if (!v.isObject() || v.member(TYPE_KEY).valid()) {
+            graphics::OwnedColor legacy;
+            if (decodeAny(v, legacy)) {
+                out = graphics::ColorTimeline(std::move(legacy));
+                return true;
+            }
         }
-        return false;
+
+        std::vector<graphics::ColorKeyframe> stops;
+        if (!v.isObject() || !set(v, "keyframes", stops)) return false;
+        graphics::ColorTimeline decoded;
+        for (auto& stop : stops) {
+            if (!decoded.addKeyframe(std::move(stop))) return false;
+        }
+        out = std::move(decoded);
+        return true;
     }
 
     ENCODE() {
-        if (v.size() == 1) return encodeAny(out, v.keyframes[0].color);
-        return false;
+        return out.writeObject([&](json::ObjectWriter& object) {
+            return object.writeValue("keyframes", [&](json::Writer& writer) { return encodeAny(writer, v.keyframes); });
+        });
     }
 CODEC_END()
 
-template <>
-struct MgPropWidgetTraits<graphics::ColorTimeline> {
-    static constexpr const char* value = "gradient";
-};
+template <> struct MgPropWidgetTraits<graphics::ColorTimeline> { static constexpr const char* value = "gradient"; };
 
 } // namespace mg

--- a/include/multigauge/graphics/colors/StaticColor.h
+++ b/include/multigauge/graphics/colors/StaticColor.h
@@ -4,48 +4,24 @@
 
 namespace mg::graphics {
 
-class StaticColor : public Color {
+class StaticColor final : public Color {
     MG_EDITOR_NAME("Static Color")
     MG_TYPE_ID("static")
 
-    private:
-        rgba color;
-
-        MG_PROPS_PARENT(Color)
-
-        MG_PROPS_BEGIN()
+    rgba color;
+    MG_PROPS_PARENT(Color)
+    MG_PROPS_BEGIN()
     MG_PROP(color, "color", "Color", "RGBA color value.")
-        MG_PROPS_END()
-    
-    public:
-        /// @brief Constructs a StaticColor with default color
-        StaticColor();
+    MG_PROPS_END()
 
-        StaticColor(rgba color);
+public:
+    StaticColor();
+    explicit StaticColor(rgba color);
+    OwnedColor clone() const override;
+    [[nodiscard]] rgba value() const noexcept { return color; }
 
-        OwnedColor clone() const override;
-
-        /// @brief Gets the static color value.
-        /// @return The 16-bit color value
-        rgba getColor() const override;
-
-        /// @brief Gets the type of this color.
-        /// @return Type::Static
-        Type getType() const override;
-
-        /// @brief Blends this color with a static color value.
-        /// @param color The 16-bit color value to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new StaticColor object with the blended result
-        OwnedColor blended(rgba color, float alpha) const override;
-
-        /// @brief Blends this color with another Color object.
-        /// @param color The Color object to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = other color)
-        /// @return A new Color object of the same derived type as the input (e.g., blending with a TimeColor returns a TimeColor)
-        OwnedColor blended(const Color& other, float alpha) const override;
-
+protected:
+    rgba resolveUncached(const ColorResolver::Frame&) const noexcept override;
 };
 
 } // namespace mg::graphics
-

--- a/include/multigauge/graphics/colors/TimeColor.h
+++ b/include/multigauge/graphics/colors/TimeColor.h
@@ -1,107 +1,53 @@
 #pragma once
 
-#include <chrono>
-
-#include <multigauge/graphics/colors/Color.h>
 #include <multigauge/graphics/colors/ColorTimeline.h>
 
 namespace mg::graphics {
 
-class TimeColor : public Color {
+class TimeColor final : public Color {
     MG_EDITOR_NAME("Time Color")
     MG_TYPE_ID("time")
-    
-    public:
-        /// @brief Defines how the timeline loops
-        enum class LoopType {
-            /// @brief Start to end repeatedly
-            Forward,
-            /// @brief End to start repeatedly
-            Reverse,
-            /// @brief Alternates between forward and reverse
-            PingPong
-        };
 
-    private:
-        static std::chrono::microseconds currentElapsed;
-        ColorTimeline timeline;
-        LoopType loopType;
+public:
+    enum class LoopType { Forward, Reverse, PingPong };
 
-        MG_PROPS_PARENT(Color)
+    TimeColor();
+    TimeColor(ColorTimeline timeline, LoopType loopType = LoopType::Forward, float periodMs = 1000.0F);
+    TimeColor(const TimeColor&) = default;
+    TimeColor& operator=(const TimeColor&) = default;
+    OwnedColor clone() const override;
 
-        MG_PROPS_BEGIN()
-    MG_PROP(timeline, "timeline", "Gradient", "Animated color gradient.")
+protected:
+    rgba resolveUncached(const ColorResolver::Frame& frame) const noexcept override;
+
+private:
+    ColorTimeline timeline;
+    LoopType loopType = LoopType::Forward;
+    float periodMs = 1000.0F;
+
+    MG_PROPS_PARENT(Color)
+    MG_PROPS_BEGIN()
+    MG_PROP(timeline, "timeline", "Gradient", "Normalized animated gradient.")
     MG_PROP(loopType, "loop", "Loop", "Type of looping to use.")
-        MG_PROPS_END()
-
-        /// @brief Retrieves the current time value.
-        /// @return The current time position in milliseconds
-        float getTime() const;
-
-    public:
-        /// Updates the shared monotonic runtime time used by all time colors.
-        static void setElapsed(std::chrono::microseconds elapsed) noexcept;
-        /// @brief Constructs a TimeColor with the default timeline and loop type.
-        TimeColor();
-
-        /// @brief Constructs a TimeColor with a specified timeline and loop type.
-        /// @param timeline The color timeline (position = time in milliseconds)
-        /// @param loopType The looping mode
-        TimeColor(ColorTimeline timeline, LoopType loopType = LoopType::Forward);
-
-        TimeColor(const TimeColor& other);
-        
-        TimeColor& operator=(const TimeColor& other);
-
-        OwnedColor clone() const override;
-
-        /// @brief Gets the current color value on the timeline.
-        /// @return The current 16-bit color value
-        rgba getColor() const override;
-
-        /// @brief Gets the type of this color.
-        /// @return Type::Time
-        Type getType() const override;
-
-        /// @brief Gets the associated color timeline
-        /// @return Pointer to the ColorTimeline
-        const ColorTimeline* getTimeline() const override;
-
-        /// @brief Blends this color with a static color value.
-        /// @param color The 16-bit color value to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new TimeColor object with the blended result
-        OwnedColor blended(rgba color, float alpha) const override;
-
-        /// @brief Blends this color with another Color object.
-        /// @param color The Color object to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = other color)
-        /// @return A new Color object with the blended result (will always be a TimeColor)
-        OwnedColor blended(const Color& other, float alpha) const override;
+    MG_PROP(periodMs, "periodMs", "Period", "Animation period in milliseconds.")
+    MG_PROPS_END()
 };
 
 } // namespace mg::graphics
 
 namespace mg {
 
-template<>
-struct EnumTraits<graphics::TimeColor::LoopType> {
+template<> struct EnumTraits<graphics::TimeColor::LoopType> {
     static constexpr EnumOption<graphics::TimeColor::LoopType> options[] = {
-        { graphics::TimeColor::LoopType::Forward,  "forward",  "Forward" },
-        { graphics::TimeColor::LoopType::Reverse,  "reverse",  "Reverse" },
+        { graphics::TimeColor::LoopType::Forward, "forward", "Forward" },
+        { graphics::TimeColor::LoopType::Reverse, "reverse", "Reverse" },
         { graphics::TimeColor::LoopType::PingPong, "pingpong", "Ping Pong" },
     };
 };
 
 CODEC_BEGIN(graphics::TimeColor::LoopType)
-    DECODE() {
-        return decodeEnum(v, out);
-    }
-
-    ENCODE() {
-        return encodeEnum(out, v);
-    }
+    DECODE() { return decodeEnum(v, out); }
+    ENCODE() { return encodeEnum(out, v); }
 CODEC_END()
 
 } // namespace mg
-

--- a/include/multigauge/graphics/colors/UserColor.h
+++ b/include/multigauge/graphics/colors/UserColor.h
@@ -4,46 +4,40 @@
 
 namespace mg::graphics {
 
-class UserColor : public Color {
+class UserColor final : public Color {
     MG_EDITOR_NAME("User Color")
     MG_TYPE_ID("user")
 
-    public:
-        enum class Slot : uint8_t {
-            Primary,
-            Secondary,
-            Background,
-        };
+public:
+    enum class Slot : std::uint8_t { Primary, Secondary, Background };
 
-    private:
-        Slot slot;
-        
-        static rgba userColors[3];
-    
-    public:
-        UserColor(Slot slot = Slot::Primary);
-        
-        OwnedColor clone() const override;
-        
-        /// @brief Gets the user-defined color value.
-        /// @return The 16-bit color value
-        rgba getColor() const override;
+    explicit UserColor(Slot slot = Slot::Primary);
+    OwnedColor clone() const override;
 
-        /// @brief Gets the type of this color.
-        /// @return Type::User
-        Type getType() const override;
+protected:
+    rgba resolveUncached(const ColorResolver::Frame& frame) const noexcept override;
 
-        /// @brief Blends this color with a static color value.
-        /// @param color The 16-bit color value to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new StaticColor object with the blended result
-        OwnedColor blended(rgba color, float alpha) const override;
-
-        /// @brief Blends this color with another Color object.
-        /// @param color The Color object to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = other color)
-        /// @return A new Color object of the same derived type as the input (e.g., blending with a TimeColor returns a TimeColor)
-        OwnedColor blended(const Color& other, float alpha) const override;
+private:
+    Slot slot;
+    MG_PROPS_PARENT(Color)
+    MG_PROPS_BEGIN()
+    MG_PROP(slot, "slot", "Slot", "User palette slot.")
+    MG_PROPS_END()
 };
 
 } // namespace mg::graphics
+
+namespace mg {
+template<> struct EnumTraits<graphics::UserColor::Slot> {
+    static constexpr EnumOption<graphics::UserColor::Slot> options[] = {
+        { graphics::UserColor::Slot::Primary, "primary", "Primary" },
+        { graphics::UserColor::Slot::Secondary, "secondary", "Secondary" },
+        { graphics::UserColor::Slot::Background, "background", "Background" },
+    };
+};
+
+CODEC_BEGIN(graphics::UserColor::Slot)
+    DECODE() { return decodeEnum(v, out); }
+    ENCODE() { return encodeEnum(out, v); }
+CODEC_END()
+} // namespace mg

--- a/include/multigauge/graphics/colors/ValueColor.h
+++ b/include/multigauge/graphics/colors/ValueColor.h
@@ -1,61 +1,32 @@
 #pragma once
 
-#include <multigauge/graphics/colors/Color.h>
 #include <multigauge/graphics/colors/ColorTimeline.h>
 #include <multigauge/value/ValueRef.h>
 
 namespace mg::graphics {
 
-class ValueColor : public Color {
+class ValueColor final : public Color {
     MG_EDITOR_NAME("Value Color")
     MG_TYPE_ID("value")
 
-    private:
-        ColorTimeline timeline;
-        ::mg::ValueRef value;
+    ColorTimeline timeline;
+    ::mg::ValueRef value;
 
-    public:
-        ValueColor() = default;
-
-        ValueColor(::mg::Value* value, ColorTimeline timeline);
-
-        ValueColor(const ValueColor& other);
-        
-        ValueColor& operator=(const ValueColor& other);
-
-        OwnedColor clone() const override;
-
-        /// @brief Gets the current color value on the timeline.
-        /// @return The current 16-bit color value
-        rgba getColor() const override;
-
-        /// @brief Gets the type of this color.
-        /// @return Type::Value
-        Type getType() const override;
-
-        /// @brief Gets the associated color timeline
-        /// @return Pointer to the ColorTimeline
-        const ColorTimeline* getTimeline() const override;
-
-        /// @brief Blends this color with a static color value.
-        /// @param color The 16-bit color value to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = blend color)
-        /// @return A new ValueColor object with the blended result
-        OwnedColor blended(rgba color, float alpha) const override;
-
-        /// @brief Blends this color with another Color object.
-        /// @param color The Color object to blend with
-        /// @param alpha The blend amount (0.0 = this color, 1.0 = other color)
-        /// @return A new Color object with the blended result (will always be a ValueColor)
-        OwnedColor blended(const Color& color, float alpha) const override;
-
-        MG_PROPS_PARENT(Color)
-
-        MG_PROPS_BEGIN()
-    MG_PROP(timeline, "timeline", "Gradient", "Value-driven color gradient.")
+    MG_PROPS_PARENT(Color)
+    MG_PROPS_BEGIN()
+    MG_PROP(timeline, "timeline", "Gradient", "Normalized value-driven gradient.")
     MG_PROP(value, "id", "ID", "Value ID.")
-        MG_PROPS_END()
+    MG_PROPS_END()
+
+public:
+    ValueColor() = default;
+    ValueColor(::mg::Value* value, ColorTimeline timeline);
+    ValueColor(const ValueColor&) = default;
+    ValueColor& operator=(const ValueColor&) = default;
+    OwnedColor clone() const override;
+
+protected:
+    rgba resolveUncached(const ColorResolver::Frame& frame) const noexcept override;
 };
 
 } // namespace mg::graphics
-

--- a/include/multigauge/runtime/RuntimeContext.h
+++ b/include/multigauge/runtime/RuntimeContext.h
@@ -22,9 +22,11 @@ class RuntimeContext {
 
         OwnedScreen screen;
         graphics::rgba backgroundColor = graphics::rgba(0, 0, 0, 255);
+        graphics::ColorFrame colorFrame;
+        const graphics::UserPalette* userPalette;
 
     public:
-        explicit RuntimeContext(graphics::GraphicsContext& graphicsContext, io::FileSystem& fs);
+        explicit RuntimeContext(graphics::GraphicsContext& graphicsContext, io::FileSystem& fs, const graphics::UserPalette& userPalette);
         ~RuntimeContext();
 
         RuntimeContext(const RuntimeContext&) = delete;
@@ -43,14 +45,13 @@ class RuntimeContext {
 
         void setBackgroundColor(graphics::rgba color);
         graphics::rgba getBackgroundColor() const;
-
         void clearScreen();
         bool setScreen(OwnedScreen screen);
 
         Screen* getScreen();
         const Screen* getScreen() const;
 
-        void frame(std::chrono::microseconds delta);
+        void frame(std::chrono::microseconds delta, std::chrono::microseconds elapsed);
 };
 
 }

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -8,11 +8,11 @@
 #include <multigauge/HandlePool.h>
 #include <multigauge/editor/Api.h>
 #include <multigauge/gauge/GaugeFace.h>
-#include <multigauge/graphics/colors/TimeColor.h>
 #include <multigauge/screens/GaugeScreen.h>
 #include <multigauge/screens/EditorScreen.h>
 #include <multigauge/io/Log.h>
 #include <multigauge/utils/Json.h>
+#include <multigauge/graphics/UserPalette.h>
 
 #include <utility>
 #include <chrono>
@@ -33,6 +33,7 @@ namespace {
     bool initialized = false;
     std::chrono::microseconds lastElapsed{};
     YGConfigRef yogaConfig = nullptr;
+    graphics::UserPalette userPalette;
 
     io::FileSystem* g_fs = nullptr;
     io::Time* g_time = nullptr;
@@ -85,13 +86,16 @@ void frame() {
     const std::chrono::microseconds delta = now >= lastElapsed ? now - lastElapsed : std::chrono::microseconds{};
     lastElapsed = now;
 
-    graphics::TimeColor::setElapsed(now);
-    for (auto& context : contexts) context.frame(delta);
+    for (auto& context : contexts) context.frame(delta, now);
 }
 
 YGConfigRef getYogaConfig() { return yogaConfig; }
 
-ContextId addContext(graphics::GraphicsContext& graphics) { return contexts.emplace(graphics, *g_fs); }
+bool setUserColor(std::size_t slot, graphics::rgba color) { return userPalette.setColor(slot, color); }
+
+graphics::rgba getUserColor(std::size_t slot) { return userPalette.color(slot); }
+
+ContextId addContext(graphics::GraphicsContext& graphics) { return contexts.emplace(graphics, *g_fs, userPalette); }
 
 bool removeContext(ContextId id) { return contexts.remove(id); }
 

--- a/src/gauge/ticks/TickList.cpp
+++ b/src/gauge/ticks/TickList.cpp
@@ -60,17 +60,7 @@ void TickList::drawCircularTick(Graphics &g, uint8_t index, Point<float> pos, fl
     Line<float> line = Line<float>(pos + unitVector * tickRadii.first, pos + unitVector * tickRadii.second);
 
     // Get the color at the current position  
-    Paint temporaryFS = color.getPaintAtPosition(value);
-
-    //if (PaintModifier.fill != nullptr) temporaryFS.blendFill(PaintModifier.fill->getColor(), highlightFactor);
-    //if (PaintModifier.stroke != nullptr) temporaryFS.blendStroke(PaintModifier.stroke->getColor(), PaintModifier.stroke->thickness, highlightFactor);
-
-    /*
-    if (fade != nullptr) { // Apply fade
-        uint8_t alpha = fade->getAlpha(position);
-        temporaryFS = temporaryFS.getBlendPaint(fade->color->getColor(), alpha);
-    }
-    */
+    const ResolvedPaint temporaryFS = color.sample(value, g.colorFrameToken());
 
     switch(style) {
         case LINE:
@@ -96,49 +86,6 @@ void TickList::drawCircularTick(Graphics &g, uint8_t index, Point<float> pos, fl
             drawCircleTick(g, line, thickness, temporaryFS);
             break;
     }
-   
-    /*
-    // Draw the value if needed
-    if (valueStyle.has_value()) {
-        double cosAngle, sinAngle; sincos(angle, &sinAngle, &cosAngle);
-
-        TickValueStyle style = valueStyle.value();
-
-        String displayValue = String((int)round(value));
-
-        // Set text parameters
-        canvas.setTextDatum(middle_center);
-        canvas.setTextFont(style.font);
-        canvas.setTextSize(1.0f * (1.0f + (highlightFactor * textSizeFactor)));
-        
-        uint16_t valueColor = style.color.getColor(value);
-
-        valueColor = blendColors(valueColor, valueColorModifier->getColor(), highlightFactor);
-
-        if (fade != nullptr) { // Apply fade
-            uint8_t alpha = fade->getAlpha(position);
-            canvas.setTextColor(alphaBlend(alpha, valueColor, fade->color->getColor()));
-        }
-
-        // Calculate the drawn values width and height
-        int stringWidth = canvas.textWidth(displayValue);
-        int stringHeight = canvas.fontHeight();
-
-        // Check if the alignment is RADIUS_INNER or if flip is enabled, but not both
-        // Also an excuse to use the cool '^' XOR operator
-        bool isInnerFlipped = (alignment == LENGTH_INNER) ^ style.flipValuesPosition;
-
-        int modifierSign = isInnerFlipped ? 1 : -1;
-
-        // Some simple math to determine a height/width modifier to draw the values at
-        int widthModifier  = cosAngle * ((stringWidth / 2)  + style.spacing) * modifierSign;
-        int heightModifier = sinAngle * ((stringHeight / 2) + style.spacing) * modifierSign;
-
-        float selectedRadii = isInnerFlipped ? tickRadii.second : tickRadii.first;
-
-        canvas.drawString(displayValue, pos.x + selectedRadii * cosAngle + widthModifier, pos.y + selectedRadii * sinAngle + heightModifier);
-    }
-    */
 }
 
 } // namespace mg::gauge

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -5,15 +5,7 @@
 
 namespace mg::graphics {
 
-rgba Graphics::getCachedColor(const Color& color) {
-    auto it = colorCache.find(&color);
-    if (it != colorCache.end())
-        return it->second;
-
-    rgba c = color.getColor();
-    colorCache[&color] = c;
-    return c;
-}
+rgba Graphics::resolveColor(const Color& color) noexcept { return colorFrame.resolve(color); }
 
 Graphics::Graphics(GraphicsContext& context) : context(&context) { }
 
@@ -21,7 +13,9 @@ Rect<int> Graphics::getScreenBounds() { return Rect<int>(0, 0, context->width(),
 
 //----------[ COLOR ]----------//
 
-void Graphics::clearColorCache() { colorCache.clear(); }
+void Graphics::beginFrame(const ColorFrame& frame) noexcept { colorFrame = colorResolver.beginFrame(frame); }
+void Graphics::endFrame() noexcept { colorFrame = {}; }
+rgba Graphics::resolve(const Color& color) const noexcept { return colorFrame.resolve(color); }
 
 void Graphics::setFill(rgba color) {
     fill.enabled = true;
@@ -29,7 +23,7 @@ void Graphics::setFill(rgba color) {
 }
 
 void Graphics::setFill(const Color *color) {
-    if (color) setFill(getCachedColor(*color));
+    if (color) setFill(resolveColor(*color));
     else fill.enabled = false;
 }
 
@@ -40,7 +34,7 @@ void Graphics::setStroke(rgba color, float t) {
 }
 
 void Graphics::setStroke(const Color *color, float t) {
-    if (color) setStroke(getCachedColor(*color), t);
+    if (color) setStroke(resolveColor(*color), t);
     else stroke.enabled = false;
 }
 
@@ -59,6 +53,11 @@ void Graphics::setPaint(const Color *f, const Color *s, float t) {
 
 void Graphics::setPaint(const Paint &paint) { setPaint(paint.fill.get(), paint.stroke.get(), paint.thickness); }
 
+void Graphics::setPaint(const ResolvedPaint& paint) {
+    if (paint.fillEnabled) setFill(paint.fill); else fill.enabled = false;
+    if (paint.strokeEnabled) setStroke(paint.stroke, paint.thickness); else stroke.enabled = false;
+}
+
 //----------[ FILL ]----------//
 
 void Graphics::fillAll() const { if (fill.enabled) context->clear(fill.value); }
@@ -66,7 +65,7 @@ void Graphics::fillAll() const { if (fill.enabled) context->clear(fill.value); }
 void Graphics::fillAll(rgba color) const { context->clear(color); }
 
 void Graphics::fillAll(const Color* color) { 
-    if (color) fillAll(getCachedColor(*color));
+    if (color) fillAll(resolveColor(*color));
     else fillAll();
 }
 
@@ -186,7 +185,7 @@ void Graphics::setTextColor(rgba color) {
 }
 
 void Graphics::setTextColor(const Color *color) { 
-    if (color) setTextColor(getCachedColor(*color));
+    if (color) setTextColor(resolveColor(*color));
     else textColor.enabled = false;
 }
 

--- a/src/graphics/colors/Color.cpp
+++ b/src/graphics/colors/Color.cpp
@@ -1,97 +1,72 @@
 #include <multigauge/graphics/colors/Color.h>
 
 #include <multigauge/graphics/colors/StaticColor.h>
-#include <multigauge/graphics/colors/ValueColor.h>
 #include <multigauge/graphics/colors/TimeColor.h>
 #include <multigauge/graphics/colors/UserColor.h>
+#include <multigauge/graphics/colors/ValueColor.h>
 
+#include <atomic>
 #include <utility>
 
 namespace mg::graphics {
 
 namespace {
-    template <typename T>
-    OwnedColor createColor() {
-        return std::make_unique<T>();
-    }
+std::atomic_uint32_t nextColorId{1};
 
-    OwnedColor createDefaultColor() {
-        return std::make_unique<StaticColor>();
-    }
-
-    using ColorDescriptor = MgPolymorphicTypeDescriptor<OwnedColor>;
-
-    static const ColorDescriptor COLOR_TYPES[] = {
-        makePolymorphicTypeDescriptor<StaticColor, OwnedColor>(&createColor<StaticColor>),
-        makePolymorphicTypeDescriptor<ValueColor, OwnedColor>(&createColor<ValueColor>),
-        makePolymorphicTypeDescriptor<TimeColor, OwnedColor>(&createColor<TimeColor>),
-        makePolymorphicTypeDescriptor<UserColor, OwnedColor>(&createColor<UserColor>),
-    };
+std::uint32_t allocateColorId() noexcept {
+    const std::uint32_t id = nextColorId.fetch_add(1, std::memory_order_relaxed);
+    return id != 0 ? id : nextColorId.fetch_add(1, std::memory_order_relaxed);
 }
 
+template <typename T>
+OwnedColor createColor() { return std::make_unique<T>(); }
+
+OwnedColor createDefaultColor() { return std::make_unique<StaticColor>(); }
+
+using ColorDescriptor = MgPolymorphicTypeDescriptor<OwnedColor>;
+const ColorDescriptor colorTypes[] = {
+    makePolymorphicTypeDescriptor<StaticColor, OwnedColor>(&createColor<StaticColor>),
+    makePolymorphicTypeDescriptor<ValueColor, OwnedColor>(&createColor<ValueColor>),
+    makePolymorphicTypeDescriptor<TimeColor, OwnedColor>(&createColor<TimeColor>),
+    makePolymorphicTypeDescriptor<UserColor, OwnedColor>(&createColor<UserColor>),
+};
+}
+
+Color::Color() noexcept : id_(allocateColorId()) {}
+Color::Color(const Color&) noexcept : id_(allocateColorId()) {}
+
 const Color::Registry& Color::registry() {
-    static const Registry registry(COLOR_TYPES, sizeof(COLOR_TYPES) / sizeof(COLOR_TYPES[0]), &createDefaultColor);
+    static const Registry registry(colorTypes, sizeof(colorTypes) / sizeof(colorTypes[0]), &createDefaultColor);
     return registry;
 }
 
-const ColorTimeline* Color::getTimeline() const { return nullptr; }
+Paint::Paint() = default;
+Paint::Paint(OwnedColor fill, OwnedColor stroke, float thickness)
+    : fill(std::move(fill)), stroke(std::move(stroke)), thickness(thickness) {}
 
 } // namespace mg::graphics
 
 namespace mg {
 
 DECODE_IMPL(graphics::OwnedColor) {
-    if (v.isNull()) {
-        out = nullptr;
+    if (v.isNull()) { out = nullptr; return true; }
+    graphics::rgba legacy;
+    if (Codec<graphics::rgba>::decode(v, legacy)) {
+        out = std::make_unique<graphics::StaticColor>(legacy);
         return true;
     }
-
-    graphics::rgba color;
-    if (!Codec<graphics::rgba>::decode(v, color)) return false;
-
-    out = std::make_unique<graphics::StaticColor>(color);
-    return true;
+    if (!v.isObject()) return false;
+    std::string_view type;
+    if (!v.member(TYPE_KEY).read(type) || !graphics::Color::registry().find(type)) return false;
+    return decodePolymorphicOwned<graphics::Color>(v, out);
 }
 
 ENCODE_IMPL(graphics::OwnedColor) {
-    if (!v) {
-        return out.null();
+    if (!v) return out.null();
+    if (std::string_view(v->typeId()) == graphics::StaticColor::staticTypeId()) {
+        return Codec<graphics::rgba>::encode(out, static_cast<const graphics::StaticColor&>(*v).value());
     }
-
-    if (v->getType() == graphics::Color::Type::Static) {
-        return Codec<graphics::rgba>::encode(out, v->getColor());
-    }
-
-    return false;
+    return encodePolymorphicOwned(out, v);
 }
 
 } // namespace mg
-
-namespace mg::graphics {
-
-//----------[ FILL STROKE ]----------//
-
-Paint::Paint() : fill(nullptr), stroke(nullptr) {}
-
-Paint::Paint(OwnedColor fill, OwnedColor stroke, float thickness) : fill(std::move(fill)), stroke(std::move(stroke)), thickness(thickness) {}
-
-Paint Paint::blended(rgba c, float alpha) const { return Paint((fill) ? fill->blended(c, alpha) : nullptr, (stroke) ? stroke->blended(c, alpha) : nullptr, thickness); }
-
-Paint Paint::blended(const Color &c, float alpha) const { return Paint((fill) ? fill->blended(c, alpha) : nullptr, (stroke) ? stroke->blended(c, alpha) : nullptr, thickness); }
-
-Paint Paint::blended(const Paint &other, float alpha) const {
-    OwnedColor outFill;
-    OwnedColor outStroke;
-
-    if (fill && other.fill) outFill = fill->blended(*other.fill, alpha);
-    else if (fill) outFill = fill->clone();
-    else if (other.fill) outFill = other.fill->clone();
-
-    if (stroke && other.stroke) outStroke = stroke->blended(*other.stroke, alpha);
-    else if (stroke) outStroke = stroke->clone();
-    else if (other.stroke) outStroke = other.stroke->clone();
-
-    return Paint(std::move(outFill), std::move(outStroke), thickness);
-}
-
-} // namespace mg::graphics

--- a/src/graphics/colors/ColorFrame.cpp
+++ b/src/graphics/colors/ColorFrame.cpp
@@ -1,0 +1,30 @@
+#include <multigauge/graphics/colors/ColorFrame.h>
+
+#include <span>
+#include <cstdint>
+
+namespace mg::graphics {
+
+void ValueSnapshot::refresh() noexcept {
+    const std::span<const ::mg::Value> source = ::mg::Value::list();
+    first_ = source.empty() ? nullptr : source.data();
+    values_.resize(source.size());
+    for (std::size_t index = 0; index < source.size(); ++index) values_[index] = source[index].valueBase();
+}
+
+float ValueSnapshot::value(const ::mg::Value* value, float fallback) const noexcept {
+    if (!first_ || !value) return fallback;
+    const std::uintptr_t first = reinterpret_cast<std::uintptr_t>(first_);
+    const std::uintptr_t address = reinterpret_cast<std::uintptr_t>(value);
+    const std::size_t bytes = values_.size() * sizeof(::mg::Value);
+    if (address < first || address - first >= bytes || (address - first) % sizeof(::mg::Value) != 0) return fallback;
+    return values_[(address - first) / sizeof(::mg::Value)];
+}
+
+void ColorFrame::refresh(std::chrono::microseconds elapsed, const UserPalette& palette) noexcept {
+    elapsed_ = elapsed;
+    palette_ = &palette;
+    values_.refresh();
+}
+
+} // namespace mg::graphics

--- a/src/graphics/colors/ColorResolver.cpp
+++ b/src/graphics/colors/ColorResolver.cpp
@@ -1,0 +1,74 @@
+#include <multigauge/graphics/colors/ColorResolver.h>
+
+#include <multigauge/graphics/colors/Color.h>
+
+namespace mg::graphics {
+
+ColorResolver::ColorResolver(std::size_t capacity) {
+    cache_.reserve(capacity);
+}
+
+bool ColorResolver::Frame::valid() const noexcept {
+    return resolver_ && resolver_->frame_ && generation_ == resolver_->generation_;
+}
+
+const ColorFrame* ColorResolver::Frame::data() const noexcept {
+    return valid() ? resolver_->frame_ : nullptr;
+}
+
+rgba ColorResolver::Frame::resolve(const Color& color) const noexcept {
+    return resolver_ ? resolver_->resolve(*this, color) : rgba{0, 0, 0, 0};
+}
+
+ColorResolver::Frame ColorResolver::beginFrame(const ColorFrame& frame) noexcept {
+    frame_ = &frame;
+    ++generation_;
+    if (generation_ == 0) {
+        generation_ = 1;
+        for (CacheEntry& entry : cache_) entry.generation = 0;
+    }
+    return Frame(this, generation_);
+}
+
+rgba ColorResolver::resolve(const Frame& frame, const Color& color) noexcept {
+    if (!frame.valid()) return rgba{0, 0, 0, 0};
+
+    std::size_t index = cache_.size();
+    std::size_t reusable = cache_.size();
+    for (std::size_t candidateIndex = 0; candidateIndex < cache_.size(); ++candidateIndex) {
+        CacheEntry& candidate = cache_[candidateIndex];
+        if (candidate.id == color.id() && candidate.color == &color) {
+            index = candidateIndex;
+            break;
+        }
+        if (reusable == cache_.size() && candidate.generation != generation_) reusable = candidateIndex;
+    }
+    if (index == cache_.size()) {
+        if (reusable != cache_.size()) {
+            index = reusable;
+            cache_[index] = CacheEntry{.id = color.id(), .color = &color};
+        } else if (cache_.size() < cache_.capacity()) {
+            cache_.push_back(CacheEntry{.id = color.id(), .color = &color});
+            index = cache_.size() - 1;
+        } else {
+            // This is a configuration error, not an allocation opportunity in
+            // a noexcept render path. The fallback remains deterministic.
+            return rgba{0, 0, 0, 0};
+        }
+    }
+
+    if (cache_[index].generation == generation_) {
+        // A resolving entry is a cycle. Transparent black is the deterministic
+        // fallback for malformed/future shared definition graphs.
+        return cache_[index].state == State::Resolved ? cache_[index].value : rgba{0, 0, 0, 0};
+    }
+
+    cache_[index].generation = generation_;
+    cache_[index].state = State::Resolving;
+    const rgba resolved = color.resolveUncached(frame);
+    cache_[index].value = resolved;
+    cache_[index].state = State::Resolved;
+    return resolved;
+}
+
+} // namespace mg::graphics

--- a/src/graphics/colors/ColorTimeline.cpp
+++ b/src/graphics/colors/ColorTimeline.cpp
@@ -1,226 +1,90 @@
 #include <multigauge/graphics/colors/ColorTimeline.h>
-#include <multigauge/graphics/colors/StaticColor.h>
-#include <multigauge/graphics/colors/TimeColor.h>
-#include <multigauge/graphics/colors/ValueColor.h>
-#include <multigauge/utils/Math.h>
-#include <set>
+
 #include <algorithm>
+#include <cmath>
 #include <utility>
+
+#include <multigauge/graphics/colors/StaticColor.h>
 
 namespace mg::graphics {
 
-using ::mg::utils::mapf;
-
-ColorKeyframe::ColorKeyframe() { }
-
-ColorKeyframe::ColorKeyframe(OwnedColor color, float position) : color(std::move(color)), position(position) { }
-
-ColorKeyframe::ColorKeyframe(const ColorKeyframe &other) : position(other.position), color(other.color ? other.color->clone() : nullptr) {}
-
-ColorKeyframe &ColorKeyframe::operator=(const ColorKeyframe &other) {
+ColorKeyframe::ColorKeyframe(OwnedColor color, float position) : position(position), color(std::move(color)) {}
+ColorKeyframe::ColorKeyframe(const ColorKeyframe& other)
+    : position(other.position), color(other.color ? other.color->clone() : nullptr) {}
+ColorKeyframe& ColorKeyframe::operator=(const ColorKeyframe& other) {
     if (this != &other) {
-        this->position = other.position;
-        this->color = other.color ? other.color->clone() : nullptr;
+        position = other.position;
+        color = other.color ? other.color->clone() : nullptr;
     }
     return *this;
 }
 
-size_t ColorTimeline::getKeyframeIndexAtPosition(float position) const {
-    const size_t n = keyframes.size();
-    if (n <= 1) return 0;
-    if (position < keyframes[1].position) return 0;
-    if (position >= keyframes.back().position) return n - 1;
-
-    size_t left = 1;
-    size_t right = n - 1;
-    while (left < right) {
-        size_t middle = (left + right) / 2;
-        if (keyframes[middle].position < position) 
-            left = middle + 1;
-        else right = middle;
-    }
-
-    return left - 1;
-}
-
-ColorTimeline::ColorTimeline() {}
-
-ColorTimeline::ColorTimeline(rgba color) { addKeyframe(color, 0.0f); }
-
-ColorTimeline::ColorTimeline(OwnedColor color) { addKeyframe(std::move(color), 0.0f); }
-
-ColorTimeline::ColorTimeline(const ColorTimeline &other) {
-    keyframes.reserve(other.keyframes.size());
-    for (const auto& keyframe : other.keyframes)
-        this->keyframes.emplace_back(keyframe);
-}
-
-ColorTimeline &ColorTimeline::operator=(const ColorTimeline &other) {
-    if (this == &other) return *this;
-
-    std::vector<ColorKeyframe> tmp;
-    tmp.reserve(other.keyframes.size());
-    for (const auto& keyframe : other.keyframes) tmp.emplace_back(keyframe);
-    keyframes = std::move(tmp);
-    return *this;
-}
-
-ColorTimeline ColorTimeline::blended(rgba color, float alpha) const {
-    ColorTimeline newTimeline;
-
-    // TODO: addKeyframe is inefficient in this case. emplace_back directly into the keyframes would be better
-    for (const auto& keyframe : keyframes)
-        newTimeline.addKeyframe(ColorKeyframe(keyframe.color->blended(color, alpha), keyframe.position));
-
-    return newTimeline;
-}
-
-ColorTimeline ColorTimeline::blended(const Color &other, float alpha) const {
-    if (const ColorTimeline* tl = other.getTimeline()) return blended(*tl, alpha);
-
-    return blended(other.getColor(), alpha);
-}
-
-ColorTimeline ColorTimeline::blended(const ColorTimeline &other, float alpha) const {
-    ColorTimeline newTimeline;
-
-    std::set<float> positions;
-    for (const auto& keyframe : this->keyframes) positions.insert(keyframe.position);
-    for (const auto& keyframe : other.keyframes) positions.insert(keyframe.position);
-
-    // TODO: this only creates static colors, figure out a way to make it work for all types
-    for (float position : positions) {
-        rgba colorA = this->getColor(position);
-        rgba colorB = other.getColor(position);
-        rgba blended = colorA.blended(colorB, alpha);
-
-        newTimeline.addKeyframe(blended, position);
-    }
-
-    return newTimeline;
-}
-
-void ColorTimeline::addKeyframe(rgba color, float position) { addKeyframe(ColorKeyframe(std::make_unique<StaticColor>(color), position)); }
-
-void ColorTimeline::addKeyframe(OwnedColor color, float position) { addKeyframe(ColorKeyframe(std::move(color), position)); }
-
-void ColorTimeline::addKeyframe(ColorKeyframe keyframe) {
-    auto it = keyframes.begin();
-    while(it != keyframes.end() && it->position < keyframe.position) ++it;
-    keyframes.insert(it, std::move(keyframe));
-}
+ColorTimeline::ColorTimeline(rgba color) { addKeyframe(color, 0.0F); }
+ColorTimeline::ColorTimeline(OwnedColor color) { addKeyframe(std::move(color), 0.0F); }
+ColorTimeline::ColorTimeline(const ColorTimeline& other) : keyframes(other.keyframes) {}
+ColorTimeline& ColorTimeline::operator=(const ColorTimeline& other) { keyframes = other.keyframes; return *this; }
 
 void ColorTimeline::clear() { keyframes.clear(); }
 
-size_t ColorTimeline::size() const { return keyframes.size(); }
-
-bool ColorTimeline::empty() const { return keyframes.empty(); }
-
-rgba ColorTimeline::getColor(float position) const {
-    if (keyframes.empty()) return DEFAULT_COLOR;
-
-    size_t index = getKeyframeIndexAtPosition(position);
-
-    if (index >= keyframes.size() - 1) return keyframes.back().color->getColor();
-
-    const float span = keyframes[index + 1].position - keyframes[index].position;
-    if (span == 0.0f) return keyframes[index + 1].color->getColor();
-
-    float normalized = (position - keyframes[index].position) / span;
-
-    return keyframes[index].color->getColor().blended(keyframes[index + 1].color->getColor(), normalized);
+bool ColorTimeline::addKeyframe(rgba color, float position) {
+    return addKeyframe(std::make_unique<StaticColor>(color), position);
 }
 
-float ColorTimeline::getStartPosition() const { return !keyframes.empty() ? keyframes.front().position : 0.0f; }
-
-float ColorTimeline::getEndPosition() const { return !keyframes.empty() ? keyframes.back().position : 0.0f; }
-
-std::vector<float> ColorTimeline::getPositions() const {
-    std::vector<float> positions;
-
-    for (const auto& keyframe : keyframes) positions.push_back(keyframe.position);
-
-    return positions;
+bool ColorTimeline::addKeyframe(OwnedColor color, float position) {
+    return addKeyframe(ColorKeyframe(std::move(color), position));
 }
 
-std::vector<float> ColorTimeline::getPositionsMapped(float start, float end) const {
-    std::vector<float> positions;
-
-    float startPosition = getStartPosition();
-    float endPosition = getEndPosition();
-
-    for (const auto& keyframe : keyframes) positions.push_back(mapf(keyframe.position, startPosition, endPosition, start, end));
-
-    return positions;
+bool ColorTimeline::addKeyframe(ColorKeyframe keyframe) {
+    if (!keyframe.color || !std::isfinite(keyframe.position) || keyframe.position < 0.0F || keyframe.position > 1.0F) return false;
+    const auto position = std::lower_bound(keyframes.begin(), keyframes.end(), keyframe.position,
+        [](const ColorKeyframe& existing, float position) { return existing.position < position; });
+    if (position != keyframes.end() && position->position == keyframe.position) return false;
+    keyframes.insert(position, std::move(keyframe));
+    return true;
 }
 
-std::vector<rgba> ColorTimeline::sample(float startPosition, float endPosition, size_t numSamples) {
-    std::vector<rgba> result;
-    if (keyframes.empty() || numSamples == 0) return result;
-    result.reserve(numSamples);
+std::size_t ColorTimeline::size() const noexcept { return keyframes.size(); }
+bool ColorTimeline::empty() const noexcept { return keyframes.empty(); }
 
-    if (numSamples == 1) {
-        result.push_back(getColor(startPosition));
-        return result;
+bool ColorTimeline::valid() const noexcept {
+    float previous = -1.0F;
+    for (const ColorKeyframe& keyframe : keyframes) {
+        if (!keyframe.color || !std::isfinite(keyframe.position) || keyframe.position < 0.0F || keyframe.position > 1.0F || keyframe.position <= previous) return false;
+        previous = keyframe.position;
     }
-
-    float step = (endPosition - startPosition) / (numSamples - 1);
-    size_t startIndex = 0;
-    size_t endIndex = (keyframes.size() > 1) ? 1 : 0;
-
-    rgba startColor = keyframes[startIndex].color->getColor();
-    rgba endColor   = keyframes[endIndex].color->getColor();
-
-    for (size_t sample = 0; sample < numSamples; ++sample) {
-        float position = startPosition + step * sample;
-
-        while (endIndex < keyframes.size() && position > keyframes[endIndex].position) {
-            startIndex = endIndex;
-            startColor = endColor;
-            endIndex++;
-            endColor = keyframes[std::min(endIndex, keyframes.size() - 1)].color->getColor();
-        }
-
-        endIndex = std::min(endIndex, keyframes.size() - 1);
-
-        float t = 0;
-        if (startIndex != endIndex) {
-            float delta = keyframes[endIndex].position - keyframes[startIndex].position;
-            t = (delta != 0) ? (position - keyframes[startIndex].position) / delta : 0;
-        }
-
-        result.push_back(startColor.blended(endColor, t));
-    }
-
-    return result;
+    return true;
 }
 
-PaintTimeline::PaintTimeline(ColorTimeline f, ColorTimeline s, float t) : fill(f), stroke(s), thickness(t) {}
-
-PaintTimeline PaintTimeline::blended(rgba color, float alpha) const {
-    return PaintTimeline(fill.blended(color, alpha), stroke.blended(color, alpha), thickness);
+std::size_t ColorTimeline::indexAt(float position) const noexcept {
+    const auto upper = std::upper_bound(keyframes.begin(), keyframes.end(), position,
+        [](float position, const ColorKeyframe& keyframe) { return position < keyframe.position; });
+    return upper == keyframes.begin() ? 0 : static_cast<std::size_t>((upper - keyframes.begin()) - 1);
 }
 
-PaintTimeline PaintTimeline::blended(const Color &color, float alpha) const {
-    return PaintTimeline(fill.blended(color, alpha), stroke.blended(color, alpha), thickness);
+rgba ColorTimeline::sample(float position, const ColorResolver::Frame& frame) const noexcept {
+    if (!frame.valid() || keyframes.empty() || !valid() || !std::isfinite(position)) return rgba{0, 0, 0, 0};
+    position = std::clamp(position, 0.0F, 1.0F);
+    if (position <= keyframes.front().position) return frame.resolve(*keyframes.front().color);
+    if (position >= keyframes.back().position) return frame.resolve(*keyframes.back().color);
+
+    const std::size_t index = indexAt(position);
+    const ColorKeyframe& left = keyframes[index];
+    const ColorKeyframe& right = keyframes[index + 1];
+    const float t = (position - left.position) / (right.position - left.position);
+    return frame.resolve(*left.color).blended(frame.resolve(*right.color), t);
 }
 
-PaintTimeline PaintTimeline::blended(const ColorTimeline &color, float alpha) const {
-    return PaintTimeline(fill.blended(color, alpha), stroke.blended(color, alpha), thickness);
-}
+PaintTimeline::PaintTimeline(ColorTimeline fill, ColorTimeline stroke, float thickness)
+    : fill(std::move(fill)), stroke(std::move(stroke)), thickness(thickness) {}
 
-PaintTimeline PaintTimeline::blended(const PaintTimeline &other, float alpha) const {
-    return PaintTimeline(fill.blended(other.fill, alpha), stroke.blended(other.stroke, alpha), (thickness + other.thickness) / 2.0f);
-}
-
-#include <multigauge/graphics/colors/StaticColor.h>
-
-Paint PaintTimeline::getPaintAtPosition(float position) const {
-    return Paint(
-        fill.empty() ? nullptr : std::make_unique<StaticColor>(fill.getColor(position)),
-        stroke.empty() ? nullptr : std::make_unique<StaticColor>(stroke.getColor(position)),
-        thickness
-    );
+ResolvedPaint PaintTimeline::sample(float position, const ColorResolver::Frame& frame) const noexcept {
+    return {
+        .fillEnabled = !fill.empty(),
+        .fill = fill.sample(position, frame),
+        .strokeEnabled = !stroke.empty(),
+        .stroke = stroke.sample(position, frame),
+        .thickness = std::max(0.0F, thickness),
+    };
 }
 
 } // namespace mg::graphics

--- a/src/graphics/colors/StaticColor.cpp
+++ b/src/graphics/colors/StaticColor.cpp
@@ -2,18 +2,9 @@
 
 namespace mg::graphics {
 
-StaticColor::StaticColor() : color(DEFAULT_COLOR) { }
-
+StaticColor::StaticColor() : color(DEFAULT_COLOR) {}
 StaticColor::StaticColor(rgba color) : color(color) {}
-
-OwnedColor StaticColor::blended(rgba color, float alpha) const { return std::make_unique<StaticColor>(this->color.blended(color, alpha)); }
-
-OwnedColor StaticColor::blended(const Color &other, float alpha) const { return other.blended(this->color, alpha); }
-
 OwnedColor StaticColor::clone() const { return std::make_unique<StaticColor>(*this); }
-
-rgba StaticColor::getColor() const { return color; }
-
-Color::Type StaticColor::getType() const { return Type::Static; }
+rgba StaticColor::resolveUncached(const ColorResolver::Frame&) const noexcept { return color; }
 
 } // namespace mg::graphics

--- a/src/graphics/colors/TimeColor.cpp
+++ b/src/graphics/colors/TimeColor.cpp
@@ -1,80 +1,37 @@
 #include <multigauge/graphics/colors/TimeColor.h>
 
 #include <cmath>
+#include <cstdint>
+#include <limits>
 #include <utility>
 
 namespace mg::graphics {
 
-std::chrono::microseconds TimeColor::currentElapsed{};
-
-void TimeColor::setElapsed(std::chrono::microseconds elapsed) noexcept {
-    currentElapsed = elapsed;
-}
-
-float TimeColor::getTime() const {
-    float duration = timeline.getEndPosition();
-
-    if (timeline.size() == 0 || duration <= 0.0f) return 0.0f;
-
-    float t = std::chrono::duration<float, std::milli>(currentElapsed).count();
-
-    switch (loopType) {
-        case LoopType::Forward:
-            t = std::fmod(t, duration);
-            break;
-        
-        case LoopType::Reverse:
-            t = duration - std::fmod(t, duration);
-            break;
-
-        case LoopType::PingPong:
-            t = std::fmod(t, 2.0f * duration);
-            if (t > duration) t = 2.0f * duration - t;
-            break;
-    }
-
-    return t;
-}
-
-const ColorTimeline *TimeColor::getTimeline() const { return &timeline; }
-
-TimeColor::TimeColor() : timeline(ColorTimeline()), loopType(LoopType::Forward) { }
-
-TimeColor::TimeColor(ColorTimeline timeline, LoopType loopType) : timeline(std::move(timeline)), loopType(loopType) {}
-
-TimeColor::TimeColor(const TimeColor &other) : timeline(other.timeline), loopType(other.loopType) {}
-
-TimeColor &TimeColor::operator=(const TimeColor &other) {
-    if (this != &other) {
-        this->timeline = other.timeline;
-        this->loopType = other.loopType;
-    }
-    return *this;
-}
-
-OwnedColor TimeColor::blended(rgba color, float alpha) const { return std::make_unique<TimeColor>(timeline.blended(color, alpha)); }
-
-OwnedColor TimeColor::blended(const Color &other, float alpha) const {
-    switch(other.getType()) {
-        case (Type::Static):
-        case (Type::User):
-            return blended(other.getColor(), alpha);
-
-        case (Type::Time):
-        case (Type::Value): {
-            const ColorTimeline* timeline = other.getTimeline();
-            if (timeline != nullptr) return std::make_unique<TimeColor>(this->timeline.blended(*timeline, alpha), this->loopType);
-        }
-    }
-
-    //return std::make_unique<TimeColor>(this->timeline, this->loopType);
-    return std::make_unique<TimeColor>();
-}
-
+TimeColor::TimeColor() = default;
+TimeColor::TimeColor(ColorTimeline timeline, LoopType loopType, float periodMs)
+    : timeline(std::move(timeline)), loopType(loopType), periodMs(periodMs) {}
 OwnedColor TimeColor::clone() const { return std::make_unique<TimeColor>(*this); }
 
-rgba TimeColor::getColor() const { return timeline.getColor(getTime()); }
+rgba TimeColor::resolveUncached(const ColorResolver::Frame& frame) const noexcept {
+    const ColorFrame* data = frame.data();
+    if (!data || !std::isfinite(periodMs) || periodMs <= 0.0F) return rgba{0, 0, 0, 0};
+    constexpr double maxPeriodMs = static_cast<double>(std::numeric_limits<std::int64_t>::max() / 2) / 1000.0;
+    if (static_cast<double>(periodMs) > maxPeriodMs) return rgba{0, 0, 0, 0};
+    const auto period = static_cast<std::int64_t>(std::llround(static_cast<double>(periodMs) * 1000.0));
+    if (period <= 0) return rgba{0, 0, 0, 0};
 
-Color::Type TimeColor::getType() const { return Type::Time; }
+    const std::int64_t elapsed = data->elapsed().count() >= 0 ? data->elapsed().count() : 0;
+    const std::int64_t phase = elapsed % period;
+    float normalized = static_cast<float>(static_cast<double>(phase) / static_cast<double>(period));
+    switch (loopType) {
+        case LoopType::Forward: break;
+        case LoopType::Reverse: normalized = 1.0F - normalized; break;
+        case LoopType::PingPong:
+            normalized = static_cast<float>(static_cast<double>(elapsed % (period * 2)) / static_cast<double>(period));
+            if (normalized > 1.0F) normalized = 2.0F - normalized;
+            break;
+    }
+    return timeline.sample(normalized, frame);
+}
 
 } // namespace mg::graphics

--- a/src/graphics/colors/UserColor.cpp
+++ b/src/graphics/colors/UserColor.cpp
@@ -1,24 +1,14 @@
 #include <multigauge/graphics/colors/UserColor.h>
-#include <multigauge/graphics/colors/StaticColor.h>
 
 namespace mg::graphics {
 
-rgba UserColor::userColors[3] = {
-    rgba("white"),     // Primary
-    rgba("red"),       // Secondary
-    rgba("black")      // Background
-};
-
-UserColor::UserColor(Slot slot) : slot(slot) { }
-
+UserColor::UserColor(Slot slot) : slot(slot) {}
 OwnedColor UserColor::clone() const { return std::make_unique<UserColor>(*this); }
 
-rgba UserColor::getColor() const { return userColors[static_cast<size_t>(slot)]; }
-
-Color::Type UserColor::getType() const { return Type::User; }
-
-OwnedColor UserColor::blended(rgba color, float alpha) const { return std::make_unique<StaticColor>(getColor().blended(color, alpha)); }
-
-OwnedColor UserColor::blended(const Color &other, float alpha) const { return other.blended(getColor(), alpha); }
+rgba UserColor::resolveUncached(const ColorResolver::Frame& frame) const noexcept {
+    const ColorFrame* data = frame.data();
+    const UserPalette* palette = data ? data->palette() : nullptr;
+    return palette ? palette->color(static_cast<std::size_t>(slot)) : rgba{0, 0, 0, 0};
+}
 
 } // namespace mg::graphics

--- a/src/graphics/colors/ValueColor.cpp
+++ b/src/graphics/colors/ValueColor.cpp
@@ -1,47 +1,23 @@
 #include <multigauge/graphics/colors/ValueColor.h>
 
+#include <algorithm>
 #include <utility>
 
 namespace mg::graphics {
 
-const ColorTimeline *ValueColor::getTimeline() const { return &timeline; }
-
-ValueColor::ValueColor(::mg::Value *value, ColorTimeline timeline) : timeline(std::move(timeline)), value(value) { }
-
-ValueColor::ValueColor(const ValueColor &other) : timeline(other.timeline), value(other.value) {}
-
-ValueColor &ValueColor::operator=(const ValueColor &other) {
-    if (this != &other) {
-        this->timeline = other.timeline;
-        this->value = other.value;
-    }
-    return *this;
-}
-
-OwnedColor ValueColor::blended(rgba color, float alpha) const { return std::make_unique<ValueColor>(this->value.get(), timeline.blended(color, alpha)); }
-
-OwnedColor ValueColor::blended(const Color &other, float alpha) const{
-    switch(other.getType()) {
-        case (Type::Static):
-        case (Type::User):
-            return blended(other.getColor(), alpha);
-
-        case (Type::Time):
-        case (Type::Value): {
-            const ColorTimeline* timeline = other.getTimeline();
-            if (timeline != nullptr) return std::make_unique<ValueColor>(this->value.get(), this->timeline.blended(*timeline, alpha));
-        }
-    }
-
-    return std::make_unique<ValueColor>(this->value.get(), this->timeline);
-}
-
+ValueColor::ValueColor(::mg::Value* value, ColorTimeline timeline) : timeline(std::move(timeline)), value(value) {}
 OwnedColor ValueColor::clone() const { return std::make_unique<ValueColor>(*this); }
 
-rgba ValueColor::getColor() const { return value ? timeline.getColor(value->valueBase()) : rgba(); }
-
-Color::Type ValueColor::getType() const { return Type::Value; }
-
-// ----------[ JSON helpers ]----------
+rgba ValueColor::resolveUncached(const ColorResolver::Frame& frame) const noexcept {
+    const ColorFrame* data = frame.data();
+    const ::mg::Value* source = value.get();
+    if (!data || !source) return rgba{0, 0, 0, 0};
+    const float minimum = source->minimumBase();
+    const float maximum = source->maximumBase();
+    const float span = maximum - minimum;
+    if (span <= 0.0F) return rgba{0, 0, 0, 0};
+    const float normalized = std::clamp((data->values().value(source) - minimum) / span, 0.0F, 1.0F);
+    return timeline.sample(normalized, frame);
+}
 
 } // namespace mg::graphics

--- a/src/runtime/RuntimeContext.cpp
+++ b/src/runtime/RuntimeContext.cpp
@@ -6,7 +6,8 @@
 
 namespace mg {
 
-RuntimeContext::RuntimeContext(graphics::GraphicsContext& context, io::FileSystem& fs) : context(&context), graphics(context), assets(fs) {}
+RuntimeContext::RuntimeContext(graphics::GraphicsContext& context, io::FileSystem& fs, const graphics::UserPalette& userPalette)
+    : context(&context), graphics(context), assets(fs), userPalette(&userPalette) {}
 
 RuntimeContext::~RuntimeContext() = default;
 
@@ -47,21 +48,22 @@ Screen* RuntimeContext::getScreen() { return screen.get(); }
 
 const Screen* RuntimeContext::getScreen() const { return screen.get(); }
 
-void RuntimeContext::frame(std::chrono::microseconds delta) {
+void RuntimeContext::frame(std::chrono::microseconds delta, std::chrono::microseconds elapsed) {
     if (!context) return;
-
-    graphics.clearColorCache();
-
-    // TODO: maybe allow graphics to handle begin/end so i dont have to do this?
     context->beginFrame();
 
     if (screen) {
         screen->update(*this, delta);
+        colorFrame.refresh(elapsed, *userPalette);
+        graphics.beginFrame(colorFrame);
         screen->draw(*this, graphics);
     } else {
+        colorFrame.refresh(elapsed, *userPalette);
+        graphics.beginFrame(colorFrame);
         graphics.fillAll(backgroundColor);
     }
 
+    graphics.endFrame();
     context->endFrame();
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(multigauge_core_tests
   test_value_view.cpp
   test_value_embed.cpp
   test_properties.cpp
+  test_colors.cpp
 )
 
 target_include_directories(multigauge_core_tests PRIVATE

--- a/tests/test_colors.cpp
+++ b/tests/test_colors.cpp
@@ -1,0 +1,110 @@
+#include <doctest/doctest.h>
+
+#include <multigauge/graphics/colors/ColorResolver.h>
+#include <multigauge/graphics/colors/StaticColor.h>
+#include <multigauge/graphics/colors/ValueColor.h>
+#include <multigauge/json/Json.h>
+#include <multigauge/properties/Codec.h>
+#include <multigauge/value/Value.h>
+
+namespace {
+
+using namespace mg::graphics;
+
+class RecursiveColor final : public Color {
+public:
+    OwnedColor clone() const override { return std::make_unique<RecursiveColor>(); }
+
+protected:
+    rgba resolveUncached(const ColorResolver::Frame& frame) const noexcept override {
+        return frame.resolve(*this);
+    }
+};
+
+ColorResolver::Frame makeFrame(ColorFrame& frame, ColorResolver& resolver, UserPalette& palette) {
+    frame.refresh(std::chrono::microseconds{}, palette);
+    return resolver.beginFrame(frame);
+}
+
+} // namespace
+
+TEST_CASE("color resolver requires a live frame token") {
+    StaticColor color(rgba{1, 2, 3, 4});
+    ColorResolver resolver;
+    const rgba fallback = ColorResolver::Frame{}.resolve(color);
+    CHECK(fallback.r == 0);
+    CHECK(fallback.g == 0);
+    CHECK(fallback.b == 0);
+    CHECK(fallback.a == 0);
+}
+
+TEST_CASE("color resolver detects recursive definitions deterministically") {
+    ColorFrame frame;
+    ColorResolver resolver;
+    UserPalette palette;
+    const auto token = makeFrame(frame, resolver, palette);
+    RecursiveColor color;
+    const rgba resolved = token.resolve(color);
+    CHECK(resolved.r == 0);
+    CHECK(resolved.g == 0);
+    CHECK(resolved.b == 0);
+    CHECK(resolved.a == 0);
+}
+
+TEST_CASE("color resolver never allocates while resolving") {
+    ColorFrame frame;
+    UserPalette palette;
+    ColorResolver resolver(1);
+    const auto token = makeFrame(frame, resolver, palette);
+    StaticColor first(rgba{1, 2, 3, 255});
+    StaticColor second(rgba{4, 5, 6, 255});
+
+    CHECK(token.resolve(first).r == 1);
+    const rgba exhausted = token.resolve(second);
+    CHECK(exhausted.r == 0);
+    CHECK(exhausted.a == 0);
+}
+
+TEST_CASE("value colors use an indexed frame snapshot and normalized ramps") {
+    mg::Value* rpm = mg::Value::find("engineRPM");
+    REQUIRE(rpm != nullptr);
+
+    ColorTimeline ramp;
+    REQUIRE(ramp.addKeyframe(rgba{0, 0, 0, 255}, 0.0F));
+    REQUIRE(ramp.addKeyframe(rgba{255, 0, 0, 255}, 1.0F));
+    ValueColor color(rpm, std::move(ramp));
+
+    rpm->setValueBase(rpm->minimumBase());
+    ColorFrame frame;
+    ColorResolver resolver;
+    UserPalette palette;
+    auto token = makeFrame(frame, resolver, palette);
+    const rgba first = token.resolve(color);
+
+    // Mutation after the snapshot cannot affect this frame.
+    rpm->setValueBase(rpm->maximumBase());
+    const rgba sameFrame = token.resolve(color);
+    CHECK(sameFrame.r == first.r);
+
+    token = makeFrame(frame, resolver, palette);
+    const rgba nextFrame = token.resolve(color);
+    CHECK(first.r == 0);
+    CHECK(nextFrame.r == 255);
+    rpm->setValueBase(rpm->minimumBase());
+}
+
+TEST_CASE("color ramps serialize complete normalized nested definitions") {
+    const mg::json::Document input = mg::json::parse(R"({"keyframes":[{"pos":0,"color":"#000000FF"},{"pos":1,"color":{"type":"user","slot":"secondary"}}]})");
+    REQUIRE(input.valid());
+
+    ColorTimeline ramp;
+    REQUIRE(mg::Codec<ColorTimeline>::decode(input.root(), ramp));
+    CHECK(ramp.size() == 2);
+    CHECK(ramp.valid());
+
+    mg::json::Document output = mg::json::object();
+    auto writer = output.writer();
+    REQUIRE(mg::Codec<ColorTimeline>::encode(writer, ramp));
+    CHECK(output.root().member("keyframes").isArray());
+    CHECK(output.root().member("keyframes").size() == 2);
+}


### PR DESCRIPTION
## What changed?

Refactored dynamic color evaluation around an explicit per-frame resolver.
- Replaced implicit Color::getColor() evaluation with ColorResolver::Frame.
- Added ColorFrame for elapsed time, indexed value snapshots, and the app-level user palette reference.
- Replaced Graphics’ unordered_map color cache and per-frame clear with a generation-stamped, bounded resolver cache.
- Refactored ColorTimeline into a normalized [0, 1] color-ramp API while retaining the type name.
- Added ResolvedPaint so timeline-based paint resolution does not allocate temporary StaticColor objects during drawing.
- Removed global TimeColor state and per-context user palette storage.
- Added an app-global UserPalette; UserColor still stores only a palette slot.
- Added complete multi-stop/nested color-ramp JSON serialization and focused color tests.

## Why?

The old design resolved dynamic colors lazily during drawing from live global or mutable state. That made frame consistency dependent on cache timing and required an allocating unordered_map cache in Graphics.
This refactor makes color evaluation deterministic for a frame, prevents repeated evaluation of the same color definition, avoids allocation in resolve(), removes global time state, and makes nested color ramps safe against recursive resolution.

## Refactoring notes

- RuntimeContext prepares ColorFrame after screen.update() and before screen.draw().
- Graphics owns the resolver/cache, but receives ColorFrame from runtime; it does not know how to acquire time, values, or preferences.
- ColorResolver owns the sole uint64_t cache generation. Entries are reused across frames instead of cleared.
- Resolver cache capacity defaults to 64 colors per frame. Packages with a larger frame color budget can call Graphics::reserveColorCache().
- Cache exhaustion and cycle detection resolve deterministically to transparent black.
- UserPalette is persistent app-level user preference state. It must be changed between frames; it is intentionally not package/editor state.
- ColorTimeline positions are normalized. ValueColor maps its value range to [0, 1]; TimeColor maps its loop phase to [0, 1].

## Behavior impact

Behavior intentionally changes in the following areas:
- Color::getColor(), getTimeline(), Color::Type, and runtime color blending APIs were removed. Consumers resolve colors through Graphics/the active frame.
- Dynamic colors now use frame-stable value/time inputs.
- TimeColor no longer uses process-global elapsed time; it uses frame elapsed time and adds serialized periodMs.
- UserColor now resolves through the global UserPalette, with serialized palette slots.
- Multi-stop ramps now serialize as a "keyframes" object. Legacy single-color ramp input continues to decode.
- Invalid colors, invalid ramps, cycles, invalid frame tokens, and resolver-capacity exhaustion resolve to transparent black.

## Testing

Added coverage for:
- invalid frame-token fallback;
- recursive color resolution fallback;
- indexed value snapshots remaining stable for a frame;
- normalized value-ramp behavior;
- bounded resolver-cache fallback without render-time allocation;
- complete nested multi-stop ramp JSON serialization.

## Migration notes

Downstream code that directly called Color::getColor() must instead resolve colors through Graphics during drawing, or through a valid ColorResolver::Frame.
Dynamic multi-stop color ramps must use normalized stop positions in [0, 1].
Code that needs more than 64 distinct color definitions in one frame should reserve capacity before drawing:
```cpp
graphics.reserveColorCache(requiredColorCount);
```
User palette changes should use:
```cpp
mg::setUserColor(slot, color);
mg::getUserColor(slot);
```

## Checklist

* [X] This PR is limited to one logical refactor
* [X] Existing behavior is preserved unless explicitly documented
* [X] Public APIs, configuration, serialization, or documentation were updated if needed
* [X] Tests were added or updated where responsibilities or boundaries changed
* [X] No debugging code, temporary files, or unrelated changes are included