### PR TITLE
Implement Sensor and SensorProvider Interfaces

### DIFF
--- a/include/multigauge/sensor/Sensor.h
+++ b/include/multigauge/sensor/Sensor.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string_view>
+
+#include <multigauge/sensor/SensorTypes.h>
+
+namespace mg {
+
+/// Read-only view of a logical sensor.
+///
+/// Sensors are intentionally passive from the caller's point of view:
+/// providers own polling and cache management, and consumers only read
+/// metadata plus the most recent sample.
+class Sensor {
+public:
+    virtual ~Sensor() = default;
+
+    /// Stable identifier for registry/editor use.
+    /// The returned view must remain valid for the lifetime of the sensor.
+    [[nodiscard]]
+    virtual std::string_view id() const noexcept = 0;
+
+    /// Human-readable display name.
+    /// The returned view must remain valid for the lifetime of the sensor.
+    [[nodiscard]]
+    virtual std::string_view name() const noexcept = 0;
+
+    /// Native output unit of the sensor, if it has one.
+    /// Returns nullptr when the sensor is unitless or unknown.
+    /// The pointed-to UnitType must outlive the sensor.
+    [[nodiscard]]
+    virtual const UnitType* unit() const noexcept = 0;
+
+    /// Native bounds reported by the sensor.
+    /// Unknown limits are represented by an empty optional inside the range.
+    [[nodiscard]]
+    virtual SensorRange nativeRange() const noexcept = 0;
+
+    /// Cached reading after the provider's last update cycle.
+    [[nodiscard]]
+    virtual SensorReading reading() const noexcept = 0;
+};
+
+} // namespace mg

--- a/include/multigauge/sensor/SensorProvider.h
+++ b/include/multigauge/sensor/SensorProvider.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <string_view>
+
+#include <multigauge/sensor/Sensor.h>
+
+namespace mg {
+
+/// Owns a group of related sensors and refreshes them from shared hardware.
+///
+/// Providers are responsible for polling, decoding, and cache invalidation.
+/// A single provider may update multiple logical sensors from one hardware
+/// transaction, so the caller only asks the provider to refresh once per cycle.
+class SensorProvider {
+public:
+    virtual ~SensorProvider() = default;
+
+    /// Stable identifier for registry/editor use.
+    /// The returned view must remain valid for the lifetime of the provider.
+    [[nodiscard]]
+    virtual std::string_view id() const noexcept = 0;
+
+    /// Human-readable display name.
+    /// The returned view must remain valid for the lifetime of the provider.
+    [[nodiscard]]
+    virtual std::string_view name() const noexcept = 0;
+
+    /// Refreshes all supplied sensors from the provider's backing hardware.
+    ///
+    /// Providers update each sensor's cached reading directly. Partial success
+    /// is represented by the individual sensor statuses, not by a summary
+    /// return value. `elapsed` is the delta time since the provider's previous
+    /// update call.
+    virtual void update(std::chrono::microseconds elapsed) noexcept = 0;
+
+    /// Number of sensors currently supplied by the provider.
+    [[nodiscard]]
+    virtual std::size_t sensorCount() const noexcept = 0;
+
+    /// Returns a borrowed sensor pointer for the given index, or nullptr.
+    [[nodiscard]]
+    virtual const Sensor* sensorAt(std::size_t index) const noexcept = 0;
+};
+
+} // namespace mg

--- a/include/multigauge/sensor/SensorTypes.h
+++ b/include/multigauge/sensor/SensorTypes.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include <multigauge/value/UnitType.h>
+
+namespace mg {
+
+/// Describes the state of a sensor's cached reading.
+///
+/// `Unavailable` means the sensor currently has no usable sample. That can
+/// happen before the first successful poll, when a source is disconnected, or
+/// when the provider intentionally withholds data for that cycle.
+///
+/// `Error` means the provider attempted to refresh the sensor and the sensor
+/// could not produce a valid sample.
+enum class SensorStatus : std::uint8_t {
+    Unavailable,
+    Available,
+    Error
+};
+
+/// Cached output from a sensor.
+struct SensorReading {
+    Measurement value = 0.0F;
+    SensorStatus status = SensorStatus::Unavailable;
+
+    [[nodiscard]]
+    constexpr bool available() const noexcept {
+        return status == SensorStatus::Available;
+    }
+
+    [[nodiscard]]
+    constexpr bool unavailable() const noexcept {
+        return status == SensorStatus::Unavailable;
+    }
+
+    [[nodiscard]]
+    constexpr bool error() const noexcept {
+        return status == SensorStatus::Error;
+    }
+};
+
+/// Native bounds reported by a sensor.
+/// Either side may be unknown.
+struct SensorRange {
+    std::optional<Measurement> minimum;
+    std::optional<Measurement> maximum;
+
+    [[nodiscard]]
+    constexpr bool hasMinimum() const noexcept {
+        return minimum.has_value();
+    }
+
+    [[nodiscard]]
+    constexpr bool hasMaximum() const noexcept {
+        return maximum.has_value();
+    }
+
+    [[nodiscard]]
+    constexpr bool empty() const noexcept {
+        return !minimum.has_value() && !maximum.has_value();
+    }
+};
+
+} // namespace mg


### PR DESCRIPTION
##  What changed?

Implements the initial public interfaces for the sensor system:
- `Sensor` interface for exposing sensor indentity, metadata, native bounds, and cached readings.
- `SensorProvier` interface for refreshing groups of related sensors from shared hardware or data sources.
- Adds supporting sensor types for reading status and optional native measurement bounds.

## Why?

This establishes the foundation contracts required by the rest of the sensor system.

Sensors are passive, read-only views of logical measurements, while providers are responsible for polling, decoding, cache updates, and invalidation. Keeping these responsibilities separate allows a single provider update to refresh multiple sensors from one hardware transaction, CAN frame, OBD request, or other shared data source.

These interfaces will be used by future sensor registry, manager, assignment, and concrete provider implementations.

## Implementation notes

- Sensor readings include their availability status so consumers do not need to query value and validity separately.
- Sensor bounds support independently unknown minimum and maximum values.
- Provider updates return no aggregate result. Individual update outcomes are represented by each sensor’s cached status.

## Checklist

- [X] This PR is limited to one logical feature or change
- [X] Public APIs, configuration, or documentation were updated if needed.
- [X] No debugging code, temporary files, or unrelated changes are included