### PR TITLE
Implement SensorManager

### DIFF
--- a/include/multigauge/sensor/SensorManager.h
+++ b/include/multigauge/sensor/SensorManager.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <chrono>
+#include <array>
+#include <cstddef>
+#include <string_view>
+
+#include <multigauge/sensor/SensorProvider.h>
+
+namespace mg {
+
+/// Fixed-capacity coordinator and index for registered sensors.
+///
+/// SensorManager borrows providers and their sensors. Providers own the sensor
+/// objects, and those objects must remain alive at stable addresses for as
+/// long as the provider stays registered.
+///
+/// Registration order is preserved for enumeration and update dispatch.
+class SensorManager {
+public:
+    static constexpr std::size_t MaxProviders = 8;
+    static constexpr std::size_t MaxSensors = 64;
+
+    /// Registers a provider and indexes all of its sensors.
+    /// Returns false when validation fails or capacity is exceeded.
+    [[nodiscard]] bool registerProvider(SensorProvider& provider) noexcept;
+
+    /// Unregisters a provider by ID and removes all of its indexed sensors.
+    /// Enumeration order for the remaining entries is preserved.
+    [[nodiscard]] bool unregisterProvider(std::string_view providerId) noexcept;
+
+    /// Clears every provider and sensor registration.
+    void clear() noexcept;
+
+    /// Updates every registered provider in registration order.
+    void update(std::chrono::microseconds elapsed) noexcept;
+
+    [[nodiscard]] std::size_t providerCount() const noexcept;
+    [[nodiscard]] std::size_t sensorCount() const noexcept;
+
+    /// Returns the provider at `index`, or nullptr when out of range.
+    [[nodiscard]] const SensorProvider* providerAt(std::size_t index) const noexcept;
+
+    /// Returns the sensor at `index`, or nullptr when out of range.
+    [[nodiscard]] const Sensor* sensorAt(std::size_t index) const noexcept;
+
+    /// Finds a provider by stable ID.
+    [[nodiscard]] const SensorProvider* findProvider(std::string_view providerId) const noexcept;
+
+    /// Finds a sensor by globally unique sensor ID.
+    [[nodiscard]] const Sensor* findSensor(std::string_view sensorId) const noexcept;
+
+private:
+    struct ProviderEntry {
+        SensorProvider* provider = nullptr;
+        std::string_view id{};
+    };
+
+    struct SensorEntry {
+        SensorProvider* provider = nullptr;
+        const Sensor* sensor = nullptr;
+        std::string_view id{};
+    };
+
+    [[nodiscard]] static bool hasDuplicatePointer(
+        const SensorProvider* provider,
+        const ProviderEntry* entries,
+        std::size_t count
+    ) noexcept;
+
+    [[nodiscard]] static bool hasDuplicateSensorPointer(
+        const Sensor* sensor,
+        const SensorEntry* entries,
+        std::size_t count
+    ) noexcept;
+
+    [[nodiscard]] static bool hasDuplicateSensorPointer(
+        const Sensor* sensor,
+        const Sensor* const* entries,
+        std::size_t count
+    ) noexcept;
+
+    [[nodiscard]] static bool hasDuplicateId(
+        std::string_view id,
+        const ProviderEntry* entries,
+        std::size_t count
+    ) noexcept;
+
+    [[nodiscard]] static bool hasDuplicateId(
+        std::string_view id,
+        const SensorEntry* entries,
+        std::size_t count
+    ) noexcept;
+
+    std::array<ProviderEntry, MaxProviders> providers_{};
+    std::array<SensorEntry, MaxSensors> sensors_{};
+    std::size_t providerCount_ = 0;
+    std::size_t sensorCount_ = 0;
+};
+
+} // namespace mg

--- a/src/sensor/SensorManager.cpp
+++ b/src/sensor/SensorManager.cpp
@@ -1,0 +1,249 @@
+#include <multigauge/sensor/SensorManager.h>
+
+namespace mg {
+namespace {
+
+template<typename Entry>
+bool hasDuplicateIdImpl(
+    std::string_view id,
+    const Entry* entries,
+    std::size_t count
+) noexcept {
+    for (std::size_t i = 0; i < count; ++i) {
+        if (entries[i].id == id) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+} // namespace
+
+bool SensorManager::hasDuplicatePointer(
+    const SensorProvider* provider,
+    const ProviderEntry* entries,
+    std::size_t count
+) noexcept {
+    for (std::size_t i = 0; i < count; ++i) {
+        if (entries[i].provider == provider) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool SensorManager::hasDuplicateSensorPointer(
+    const Sensor* sensor,
+    const SensorEntry* entries,
+    std::size_t count
+) noexcept {
+    for (std::size_t i = 0; i < count; ++i) {
+        if (entries[i].sensor == sensor) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool SensorManager::hasDuplicateSensorPointer(
+    const Sensor* sensor,
+    const Sensor* const* entries,
+    std::size_t count
+) noexcept {
+    for (std::size_t i = 0; i < count; ++i) {
+        if (entries[i] == sensor) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool SensorManager::hasDuplicateId(
+    std::string_view id,
+    const ProviderEntry* entries,
+    std::size_t count
+) noexcept {
+    return hasDuplicateIdImpl(id, entries, count);
+}
+
+bool SensorManager::hasDuplicateId(
+    std::string_view id,
+    const SensorEntry* entries,
+    std::size_t count
+) noexcept {
+    return hasDuplicateIdImpl(id, entries, count);
+}
+
+bool SensorManager::registerProvider(SensorProvider& provider) noexcept {
+    SensorProvider* providerPtr = &provider;
+    const std::string_view providerId = provider.id();
+
+    if (providerId.empty()) {
+        return false;
+    }
+
+    if (providerCount_ >= MaxProviders) {
+        return false;
+    }
+
+    if (hasDuplicatePointer(providerPtr, providers_.data(), providerCount_)) {
+        return false;
+    }
+
+    if (hasDuplicateId(providerId, providers_.data(), providerCount_)) {
+        return false;
+    }
+
+    const std::size_t sensorTotal = provider.sensorCount();
+    if (sensorTotal > MaxSensors - sensorCount_) {
+        return false;
+    }
+
+    std::array<const Sensor*, MaxSensors> stagedSensors{};
+    std::array<std::string_view, MaxSensors> stagedIds{};
+
+    for (std::size_t index = 0; index < sensorTotal; ++index) {
+        const Sensor* sensor = provider.sensorAt(index);
+        if (!sensor) {
+            return false;
+        }
+
+        const std::string_view sensorId = sensor->id();
+        if (sensorId.empty()) {
+            return false;
+        }
+
+        if (hasDuplicateSensorPointer(sensor, stagedSensors.data(), index)) {
+            return false;
+        }
+
+        for (std::size_t stagedIndex = 0; stagedIndex < index; ++stagedIndex) {
+            if (stagedIds[stagedIndex] == sensorId) {
+                return false;
+            }
+        }
+
+        if (hasDuplicateId(sensorId, sensors_.data(), sensorCount_)) {
+            return false;
+        }
+
+        if (hasDuplicateSensorPointer(sensor, sensors_.data(), sensorCount_)) {
+            return false;
+        }
+
+        stagedSensors[index] = sensor;
+        stagedIds[index] = sensorId;
+    }
+
+    providers_[providerCount_] = { providerPtr, providerId };
+    ++providerCount_;
+
+    for (std::size_t index = 0; index < sensorTotal; ++index) {
+        sensors_[sensorCount_ + index] = {
+            providerPtr,
+            stagedSensors[index],
+            stagedIds[index]
+        };
+    }
+
+    sensorCount_ += sensorTotal;
+    return true;
+}
+
+bool SensorManager::unregisterProvider(std::string_view providerId) noexcept {
+    if (providerId.empty()) {
+        return false;
+    }
+
+    std::size_t providerIndex = providerCount_;
+    for (std::size_t index = 0; index < providerCount_; ++index) {
+        if (providers_[index].id == providerId) {
+            providerIndex = index;
+            break;
+        }
+    }
+
+    if (providerIndex == providerCount_) {
+        return false;
+    }
+
+    SensorProvider* provider = providers_[providerIndex].provider;
+
+    for (std::size_t index = providerIndex + 1; index < providerCount_; ++index) {
+        providers_[index - 1] = providers_[index];
+    }
+    --providerCount_;
+
+    std::size_t nextSensorIndex = 0;
+    for (std::size_t index = 0; index < sensorCount_; ++index) {
+        if (sensors_[index].provider == provider) {
+            continue;
+        }
+
+        sensors_[nextSensorIndex++] = sensors_[index];
+    }
+
+    sensorCount_ = nextSensorIndex;
+    return true;
+}
+
+void SensorManager::clear() noexcept {
+    providerCount_ = 0;
+    sensorCount_ = 0;
+}
+
+void SensorManager::update(std::chrono::microseconds elapsed) noexcept {
+    for (std::size_t index = 0; index < providerCount_; ++index) {
+        providers_[index].provider->update(elapsed);
+    }
+}
+
+std::size_t SensorManager::providerCount() const noexcept {
+    return providerCount_;
+}
+
+std::size_t SensorManager::sensorCount() const noexcept {
+    return sensorCount_;
+}
+
+const SensorProvider* SensorManager::providerAt(std::size_t index) const noexcept {
+    return index < providerCount_ ? providers_[index].provider : nullptr;
+}
+
+const Sensor* SensorManager::sensorAt(std::size_t index) const noexcept {
+    return index < sensorCount_ ? sensors_[index].sensor : nullptr;
+}
+
+const SensorProvider* SensorManager::findProvider(std::string_view providerId) const noexcept {
+    if (providerId.empty()) {
+        return nullptr;
+    }
+
+    for (std::size_t index = 0; index < providerCount_; ++index) {
+        if (providers_[index].id == providerId) {
+            return providers_[index].provider;
+        }
+    }
+
+    return nullptr;
+}
+
+const Sensor* SensorManager::findSensor(std::string_view sensorId) const noexcept {
+    if (sensorId.empty()) {
+        return nullptr;
+    }
+
+    for (std::size_t index = 0; index < sensorCount_; ++index) {
+        if (sensors_[index].id == sensorId) {
+            return sensors_[index].sensor;
+        }
+    }
+
+    return nullptr;
+}
+
+} // namespace mg


### PR DESCRIPTION
##  What changed?

Added an initial `SensorManager` public API to coordinate registered sensor providers and index their sensors. The manager now supports registering and unregistering providers, updating all providers, looking up providers and sensors by ID, enumerating them by index, and clearing registrations.

## Why?

This gives the sensor system a single public coordination point without introducing a separate registry class. It keeps the design lightweight for embedded use while establishing the ownership and lifetime rules needed for future sensor providers and sensor-to-value assignment work.

## Implementation notes

`SensorManager` is intentionally non-owning: it borrows providers and sensors instead of taking ownership of them. Providers still own or control the lifetime of their sensors, and those sensor objects must remain alive at stable addresses while registered.

The manager uses fixed-capacity storage only, so registration is bounded and allocation-free. Provider registration is transactional: the manager validates the full provider and all of its sensors before mutating internal state, and it rejects duplicate provider IDs, duplicate sensor IDs, null sensors, and capacity overflows.

Enumeration and update dispatch preserve registration order. Removing a provider also removes every sensor indexed from that provider while leaving the remaining registrations intact.

## Checklist

- [X] This PR is limited to one logical feature or change
- [X] Public APIs, configuration, or documentation were updated if needed.
- [X] No debugging code, temporary files, or unrelated changes are included