### PR TITLE
Refactor/cpp 20 properties

### DIFF
--- a/include/multigauge/graphics/colors/ColorTimeline.h
+++ b/include/multigauge/graphics/colors/ColorTimeline.h
@@ -101,7 +101,7 @@ CODEC_BEGIN(graphics::ColorTimeline)
         }
 
         std::vector<graphics::ColorKeyframe> stops;
-        if (!v.isObject() || !set(v, "keyframes", stops)) return false;
+        if (!v.isObject() || !decodeAny(v.member("keyframes"), stops)) return false;
         graphics::ColorTimeline decoded;
         for (auto& stop : stops) {
             if (!decoded.addKeyframe(std::move(stop))) return false;

--- a/include/multigauge/properties/Codec.h
+++ b/include/multigauge/properties/Codec.h
@@ -3,11 +3,11 @@
 #include <multigauge/json/Json.h>
 
 #include <cmath>
+#include <concepts>
 #include <cstdint>
 #include <limits>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -16,25 +16,24 @@ namespace mg {
 class PropertyObject;
 template<typename T> struct Codec;
 
-template <typename T, typename = void> struct HasCodec : std::false_type {};
-template <typename T> struct HasCodec<T, std::void_t<
-    decltype(Codec<T>::decode(std::declval<json::Reader>(), std::declval<T&>())),
-    decltype(Codec<T>::encode(std::declval<json::Writer&>(), std::declval<const T&>()))
->> : std::true_type {};
-template <typename T> inline constexpr bool HasCodecV = HasCodec<T>::value;
+/// A codec that can losslessly participate in the property serialization path.
+template <typename T>
+concept CodecFor = requires(json::Reader reader, json::Writer& writer, T& out, const T& value) {
+    { Codec<T>::decode(reader, out) } -> std::same_as<bool>;
+    { Codec<T>::encode(writer, value) } -> std::same_as<bool>;
+};
 
 template <typename T> bool decodeAny(json::Reader value, T& out);
 template <typename T> bool encodeAny(json::Writer& writer, const T& value);
 
-template <class T> struct mg_remove_cvref { using type = std::remove_cv_t<std::remove_reference_t<T>>; };
 #define CODEC_FRIEND(T) friend struct Codec<T>;
-#define CODEC_BEGIN(CODEC_T) template<> struct Codec<CODEC_T> { using CodecType = CODEC_T;
-#define CODEC_BEGIN_TPARAMS(TPARAMS, CODEC_T) template<TPARAMS> struct Codec<CODEC_T> { using CodecType = CODEC_T;
+#define CODEC_BEGIN(CODEC_T) template <> struct Codec<CODEC_T> { using CodecType = CODEC_T;
+#define CODEC_BEGIN_TPARAMS(TPARAMS, CODEC_T) template <TPARAMS> struct Codec<CODEC_T> { using CodecType = CODEC_T;
+#define CODEC_END() };
 #define DECODE() static bool decode(::mg::json::Reader v, CodecType& out)
 #define ENCODE() static bool encode(::mg::json::Writer& out, const CodecType& v)
-#define CODEC_END() };
-#define DECODE_IMPL(CODEC_T) bool Codec<CODEC_T>::decode(::mg::json::Reader v, CodecType& out)
-#define ENCODE_IMPL(CODEC_T) bool Codec<CODEC_T>::encode(::mg::json::Writer& out, const CodecType& v)
+#define DECODE_IMPL(CODEC_T) bool Codec<CODEC_T>::decode(::mg::json::Reader v, CODEC_T& out)
+#define ENCODE_IMPL(CODEC_T) bool Codec<CODEC_T>::encode(::mg::json::Writer& out, const CODEC_T& v)
 
 CODEC_BEGIN(bool)
     DECODE() { return v.read(out); }

--- a/include/multigauge/properties/Codec.h
+++ b/include/multigauge/properties/Codec.h
@@ -13,69 +13,69 @@
 
 namespace mg {
 
-class PropertyObject;
-template<typename T> struct Codec;
+class PropertyObject; // Forward declaration
 
-/// A codec that can losslessly participate in the property serialization path.
+
+/// @brief Serialization adapter for a type used by the property system.
+/// @tparam T Type serialized by the codec.
+template<typename T>
+struct Codec;
+
+/// @brief Determines whether a type provides a valid property codec.
+/// @tparam T Type to test.
 template <typename T>
 concept CodecFor = requires(json::Reader reader, json::Writer& writer, T& out, const T& value) {
     { Codec<T>::decode(reader, out) } -> std::same_as<bool>;
     { Codec<T>::encode(writer, value) } -> std::same_as<bool>;
 };
 
-template <typename T> bool decodeAny(json::Reader value, T& out);
-template <typename T> bool encodeAny(json::Writer& writer, const T& value);
+/// @brief Decodes a value through the property serialization system.
+/// @tparam T Destination type.
+/// @param value JSON value to decode.
+/// @param out Destination receiving the decoded value.
+/// @return true if decoding succeeds; otherwise false.
+template <typename T> bool decodeAny(
+    json::Reader value,
+    T& out
+);
 
+/// @brief Encodes a value through the property serialization system.
+/// @tparam T Value type.
+/// @param writer JSON writer receiving the encoded value.
+/// @param value Value to encode.
+/// @return true if encoding succeeds; otherwise false.
+template <typename T> bool encodeAny(
+    json::Writer& writer,
+    const T& value
+);
+
+//----------[ MACROS ]----------//
+
+/// @brief Grants Codec<T> access to private members of a type.
 #define CODEC_FRIEND(T) friend struct Codec<T>;
+
+/// @brief Begins a full specialization of Codec for a concrete type.
 #define CODEC_BEGIN(CODEC_T) template <> struct Codec<CODEC_T> { using CodecType = CODEC_T;
+
+/// @brief Begins a templated Codec specialization.
 #define CODEC_BEGIN_TPARAMS(TPARAMS, CODEC_T) template <TPARAMS> struct Codec<CODEC_T> { using CodecType = CODEC_T;
+
+/// @brief Ends a Codec specialization declared with CODEC_BEGIN.
 #define CODEC_END() };
+
+/// @brief Declares the standard decode function for a Codec specialization.
 #define DECODE() static bool decode(::mg::json::Reader v, CodecType& out)
+
+/// @brief Declares the standard encode function for a Codec specialization.
 #define ENCODE() static bool encode(::mg::json::Writer& out, const CodecType& v)
+
+/// @brief Defines an out-of-line Codec decode function.
 #define DECODE_IMPL(CODEC_T) bool Codec<CODEC_T>::decode(::mg::json::Reader v, CODEC_T& out)
+
+/// @brief Defines an out-of-line Codec encode function.
 #define ENCODE_IMPL(CODEC_T) bool Codec<CODEC_T>::encode(::mg::json::Writer& out, const CODEC_T& v)
-
-CODEC_BEGIN(bool)
-    DECODE() { return v.read(out); }
-    ENCODE() { return out.write(v); }
-CODEC_END()
-
-CODEC_BEGIN(int)
-    DECODE() { std::int64_t decoded; if (!v.read(decoded) || decoded < std::numeric_limits<int>::min() || decoded > std::numeric_limits<int>::max()) return false; out = static_cast<int>(decoded); return true; }
-    ENCODE() { return out.write(v); }
-CODEC_END()
-
-CODEC_BEGIN(std::int8_t)
-    DECODE() { std::int64_t decoded; if (!v.read(decoded) || decoded < std::numeric_limits<std::int8_t>::min() || decoded > std::numeric_limits<std::int8_t>::max()) return false; out = static_cast<std::int8_t>(decoded); return true; }
-    ENCODE() { return out.write(static_cast<int>(v)); }
-CODEC_END()
-
-CODEC_BEGIN(float)
-    DECODE() { double decoded; if (!v.read(decoded) || !std::isfinite(decoded) || decoded < -std::numeric_limits<float>::max() || decoded > std::numeric_limits<float>::max()) return false; out = static_cast<float>(decoded); return true; }
-    ENCODE() { return out.write(v); }
-CODEC_END()
-
-CODEC_BEGIN(std::string)
-    DECODE() { std::string_view decoded; if (!v.read(decoded)) return false; out.assign(decoded); return true; }
-    ENCODE() { return out.write(v); }
-CODEC_END()
-
-CODEC_BEGIN_TPARAMS(typename T, std::optional<T>)
-    DECODE() { if (v.isNull()) { out.reset(); return true; } T decoded{}; if (!decodeAny(v, decoded)) return false; out = std::move(decoded); return true; }
-    ENCODE() { return v ? encodeAny(out, *v) : out.null(); }
-CODEC_END()
-
-CODEC_BEGIN_TPARAMS(typename T, std::vector<T>)
-    DECODE() { if (!v.isArray()) return false; CodecType decoded; decoded.reserve(v.size()); for (std::size_t i = 0; i < v.size(); ++i) { T element{}; if (!decodeAny(v.element(i), element)) return false; decoded.push_back(std::move(element)); } out = std::move(decoded); return true; }
-    ENCODE() { return out.writeArray([&](json::ArrayWriter&) { for (const auto& element : v) { if (!encodeAny(out, element)) return false; } return true; }); }
-CODEC_END()
-
-template<typename T>
-inline bool set(json::Reader object, std::string_view key, T& out) {
-    const json::Reader value = object.member(key);
-    return value.valid() && decodeAny(value, out);
-}
 
 } // namespace mg
 
 #include <multigauge/properties/PropertyCodec.h>
+#include <multigauge/properties/codecs/StandardCodecs.h>

--- a/include/multigauge/properties/EnumTraits.h
+++ b/include/multigauge/properties/EnumTraits.h
@@ -7,27 +7,98 @@
 #include <type_traits>
 
 namespace mg {
-template <typename T> struct EnumOption { T value; const char* key; const char* label; };
-template <typename T> struct EnumTraits;
-template <typename T>
-concept EnumDescribed = requires { EnumTraits<T>::options; };
-template <typename T> struct EnumTraitsType { using type = std::remove_cv_t<std::remove_reference_t<T>>; };
-template <typename T> struct EnumTraitsType<std::optional<T>> { using type = typename EnumTraitsType<T>::type; };
-template <typename T> using EnumTraitsTypeT = typename EnumTraitsType<T>::type;
 
-template <typename E> bool decodeEnum(json::Reader value, E& out) {
-    std::string_view key; if (!value.read(key)) return false;
-    for (const auto& option : EnumTraits<E>::options) if (key == option.key) { out = option.value; return true; }
+/// @brief Describes a serializable enum option.
+/// @tparam T Enum type represented by this option.
+template <typename T>
+struct EnumOption {
+    T value;
+    const char* key;
+    const char* label;
+};
+
+/// @brief Provides metadata describing the serializable values of an enum.
+/// @tparam T Enum type being described.
+template <typename T>
+struct EnumTraits;
+
+/// @brief Determines whether an enum type provides EnumTraits metadata.
+template <typename T>
+concept EnumDescribed = requires {
+    EnumTraits<T>::options;
+};
+
+/// @brief Resolves the underlying type used for enum metadata lookup.
+template <typename T>
+struct EnumTraitsType {
+    using type = std::remove_cv_t<std::remove_reference_t<T>>;
+};
+
+/// @brief Resolves optional enum types to their contained enum type.
+template <typename T>
+struct EnumTraitsType<std::optional<T>> {
+    using type = typename EnumTraitsType<T>::type;
+};
+
+/// @brief Convenience alias for the normalized enum matadata type. 
+template <typename T>
+using EnumTraitsTypeT = typename EnumTraitsType<T>::type;
+
+
+/// @brief Decodes an enum from its serialized key.
+/// @tparam E Described enum type.
+/// @param value JSON value containing the enum key.
+/// @param out Destination receiving the decoded enum value.
+/// @return true if the key matches a declared enum option; otherwise false.
+template <typename E>
+bool decodeEnum(json::Reader value, E& out) {
+    std::string_view key;
+    if (!value.read(key)) return false;
+
+    for (const auto& option : EnumTraits<E>::options) {
+        if (key == option.key) {
+            out = option.value;
+            return true;
+        }
+    }
+
     return false;
 }
-template <typename E> bool encodeEnum(json::Writer& writer, E value) {
-    for (const auto& option : EnumTraits<E>::options) if (option.value == value) return writer.write(option.key);
+
+/// @brief Encodes an enum using its serialized key.
+/// @tparam E Described enum type.
+/// @param writer JSON writer receiving the encoded key.
+/// @param value Enum value to encode.
+/// @return true if the value matches a declared enum option and is written successfully; otherwise false.
+template <typename E>
+bool encodeEnum(json::Writer& writer, E value) {
+    for (const auto& option : EnumTraits<E>::options) {
+        if (option.value == value) {
+            return writer.write(option.key);
+        }
+    }
+
     return false;
 }
-template <typename E> bool enumOptionsMeta(json::Writer& writer) {
+
+/// @brief Writes editor metadata for all declared values of an enum.
+/// @tparam E Described enum type.
+/// @param writer JSON writer receiving the option metadata.
+/// @return true if all option metadata is written successfully; otherwise false.
+template <typename E>
+bool enumOptionsMeta(json::Writer& writer) {
     return writer.writeArray([&](json::ArrayWriter& options) {
-        for (const auto& option : EnumTraits<E>::options) if (!options.writeObject([&](json::ObjectWriter& entry) { return entry.write("value", option.key) && entry.write("label", option.label ? option.label : option.key); })) return false;
+        for (const auto& option : EnumTraits<E>::options) {
+            if (!options.writeObject([&](json::ObjectWriter& entry) {
+                return entry.write("value", option.key)
+                    && entry.write("label", option.label ? option.label : option.key);
+            })) {
+                return false;
+            }
+        }
+
         return true;
     });
 }
+
 } // namespace mg

--- a/include/multigauge/properties/EnumTraits.h
+++ b/include/multigauge/properties/EnumTraits.h
@@ -2,15 +2,15 @@
 
 #include <multigauge/json/Json.h>
 
+#include <concepts>
 #include <optional>
 #include <type_traits>
 
 namespace mg {
 template <typename T> struct EnumOption { T value; const char* key; const char* label; };
 template <typename T> struct EnumTraits;
-template <typename T, typename = void> struct HasEnumTraits : std::false_type {};
-template <typename T> struct HasEnumTraits<T, std::void_t<decltype(EnumTraits<T>::options)>> : std::true_type {};
-template <typename T> inline constexpr bool HasEnumTraitsV = HasEnumTraits<T>::value;
+template <typename T>
+concept EnumDescribed = requires { EnumTraits<T>::options; };
 template <typename T> struct EnumTraitsType { using type = std::remove_cv_t<std::remove_reference_t<T>>; };
 template <typename T> struct EnumTraitsType<std::optional<T>> { using type = typename EnumTraitsType<T>::type; };
 template <typename T> using EnumTraitsTypeT = typename EnumTraitsType<T>::type;

--- a/include/multigauge/properties/PolymorphicRegistry.h
+++ b/include/multigauge/properties/PolymorphicRegistry.h
@@ -3,6 +3,7 @@
 #include <multigauge/json/Json.h>
 
 #include <cstddef>
+#include <span>
 #include <string_view>
 
 namespace mg {
@@ -44,26 +45,20 @@ public:
 
     /// @brief Constructs a registry over an existing descriptor array.
     /// @param descriptors Registered type descriptors.
-    /// @param count Number of descriptors in the array.
     /// @param fallback Factory used when no matching registered type is found.
-    constexpr MgPolymorphicRegistry(
-        const Descriptor* descriptors,
-        std::size_t count,
-        Creator fallback
-    )
+    constexpr MgPolymorphicRegistry(std::span<const Descriptor> descriptors, Creator fallback)
         : descriptors_(descriptors),
-          count_(count),
           fallback_(fallback) {}
 
     /// @brief Finds a registered type by identifier.
     /// @param type Type identifier to find.
     /// @return Matching descriptor, or nullptr if no type matches.
-    const Descriptor* find(std::string_view type) const {
+    [[nodiscard]] constexpr const Descriptor* find(std::string_view type) const noexcept {
         if (type.empty()) return nullptr;
 
-        for (std::size_t i = 0; i < count_; ++i) {
-            if (descriptors_[i].id && type == descriptors_[i].id) {
-                return &descriptors_[i];
+        for (const Descriptor& descriptor : descriptors_) {
+            if (descriptor.id && type == descriptor.id) {
+                return &descriptor;
             }
         }
 
@@ -74,7 +69,7 @@ public:
     /// @param type Type identifier to create.
     /// @param args Arguments forwarded to the selected factory.
     /// @return Created instance, the fallback instance if configured, or an empty owner.
-    Owned create(std::string_view type, Args... args) const {
+    [[nodiscard]] Owned create(std::string_view type, Args... args) const {
         if (const Descriptor* descriptor = find(type);
             descriptor && descriptor->create) {
             return descriptor->create(args...);
@@ -83,17 +78,16 @@ public:
         return fallback_ ? fallback_(args...) : Owned{};
     }
 
-    const Descriptor* begin() const { return descriptors_; }
-    const Descriptor* end() const { return descriptors_ + count_; }
-    std::size_t size() const { return count_; }
+    [[nodiscard]] constexpr const Descriptor* begin() const noexcept { return descriptors_.data(); }
+    [[nodiscard]] constexpr const Descriptor* end() const noexcept { return descriptors_.data() + descriptors_.size(); }
+    [[nodiscard]] constexpr std::size_t size() const noexcept { return descriptors_.size(); }
 
     /// @brief Writes editor metadata for all registered polymorphic types.
     /// @param writer JSON writer receiving the type metadata.
     /// @return true if all metadata is written successfully; otherwise false.
-    bool writeTypesMeta(json::Writer& writer) const {
+    [[nodiscard]] bool writeTypesMeta(json::Writer& writer) const {
         return writer.writeArray([&](json::ArrayWriter& types) {
-            for (std::size_t i = 0; i < count_; ++i) {
-                const auto& descriptor = descriptors_[i];
+            for (const Descriptor& descriptor : descriptors_) {
 
                 if (!types.writeObject([&](json::ObjectWriter& entry) {
                     return entry.write("id", descriptor.id ? descriptor.id : "")
@@ -108,8 +102,7 @@ public:
     }
 
 private:
-    const Descriptor* descriptors_ = nullptr;
-    std::size_t count_ = 0;
+    std::span<const Descriptor> descriptors_;
     Creator fallback_ = nullptr;
 };
 

--- a/include/multigauge/properties/PolymorphicRegistry.h
+++ b/include/multigauge/properties/PolymorphicRegistry.h
@@ -6,19 +6,136 @@
 #include <string_view>
 
 namespace mg {
-template <typename Owned, typename... Args> struct MgPolymorphicTypeDescriptor { const char* id; const char* name; Owned (*create)(Args...); };
-template <typename Derived, typename Owned, typename... Args> constexpr MgPolymorphicTypeDescriptor<Owned, Args...> makePolymorphicTypeDescriptor(Owned (*create)(Args...)) { return {Derived::staticTypeId(), Derived::staticTypeName(), create}; }
-template <typename Owned, typename... Args> class MgPolymorphicRegistry {
-public:
-    using Descriptor = MgPolymorphicTypeDescriptor<Owned, Args...>; using Creator = Owned (*)(Args...);
-    constexpr MgPolymorphicRegistry(const Descriptor* descriptors, std::size_t count, Creator fallback) : descriptors_(descriptors), count_(count), fallback_(fallback) {}
-    const Descriptor* find(std::string_view type) const { if (type.empty()) return nullptr; for (std::size_t i = 0; i < count_; ++i) if (descriptors_[i].id && type == descriptors_[i].id) return &descriptors_[i]; return nullptr; }
-    Owned create(std::string_view type, Args... args) const { if (const Descriptor* descriptor = find(type); descriptor && descriptor->create) return descriptor->create(args...); return fallback_ ? fallback_(args...) : Owned{}; }
-    const Descriptor* begin() const { return descriptors_; } const Descriptor* end() const { return descriptors_ + count_; } std::size_t size() const { return count_; }
-    bool writeTypesMeta(json::Writer& writer) const { return writer.writeArray([&](json::ArrayWriter& types) { for (std::size_t i = 0; i < count_; ++i) { const auto& d = descriptors_[i]; if (!types.writeObject([&](json::ObjectWriter& entry) { return entry.write("id", d.id ? d.id : "") && entry.write("name", d.name ? d.name : ""); })) return false; } return true; }); }
-private: const Descriptor* descriptors_ = nullptr; std::size_t count_ = 0; Creator fallback_ = nullptr;
+
+/// @brief Describes a concrete type available through a polymorphic registry.
+/// @tparam Owned Owning type returned when creating an instance.
+/// @tparam Args Arguments forwarded to the creation function.
+template <typename Owned, typename... Args>
+struct MgPolymorphicTypeDescriptor {
+    const char* id;             ///< Stable type identifier used for serialization and lookup.
+    const char* name;           ///< Human-readable type name shown in the editor.
+    Owned (*create)(Args...);   ///< Factory function used to create an instance.
 };
-template <typename T, typename = void> struct MgPolymorphicRegistryTraits { static constexpr bool supported = false; static bool getTypesMeta(json::Writer& writer) { return writer.writeArray([](json::ArrayWriter&) { return true; }); } };
-#define MG_POLYMORPHIC_REGISTRY(owned_type) using Registry = MgPolymorphicRegistry<owned_type>; static const Registry& registry();
-#define MG_POLYMORPHIC_REGISTRY_WITH_ARGS(owned_type, ...) using Registry = MgPolymorphicRegistry<owned_type, __VA_ARGS__>; static const Registry& registry();
+
+/// @brief Creates a polymorphic type descriptor for a derived type.
+/// @tparam Derived Concrete type being registered.
+/// @tparam Owned Owning type returned by the factory.
+/// @tparam Args Arguments accepted by the factory.
+/// @param create Factory function used to create the derived type.
+/// @return Descriptor containing the derived type metadata and factory.
+template <typename Derived, typename Owned, typename... Args>
+constexpr MgPolymorphicTypeDescriptor<Owned, Args...>
+makePolymorphicTypeDescriptor(Owned (*create)(Args...)) {
+    return {
+        Derived::staticTypeId(),
+        Derived::staticTypeName(),
+        create
+    };
+}
+
+/// @brief Registry of concrete types available for a polymorphic base type.
+/// @tparam Owned Owning type returned when creating registered instances.
+/// @tparam Args Arguments forwarded to registered factory functions.
+template <typename Owned, typename... Args>
+class MgPolymorphicRegistry {
+public:
+    using Descriptor = MgPolymorphicTypeDescriptor<Owned, Args...>;
+    using Creator = Owned (*)(Args...);
+
+    /// @brief Constructs a registry over an existing descriptor array.
+    /// @param descriptors Registered type descriptors.
+    /// @param count Number of descriptors in the array.
+    /// @param fallback Factory used when no matching registered type is found.
+    constexpr MgPolymorphicRegistry(
+        const Descriptor* descriptors,
+        std::size_t count,
+        Creator fallback
+    )
+        : descriptors_(descriptors),
+          count_(count),
+          fallback_(fallback) {}
+
+    /// @brief Finds a registered type by identifier.
+    /// @param type Type identifier to find.
+    /// @return Matching descriptor, or nullptr if no type matches.
+    const Descriptor* find(std::string_view type) const {
+        if (type.empty()) return nullptr;
+
+        for (std::size_t i = 0; i < count_; ++i) {
+            if (descriptors_[i].id && type == descriptors_[i].id) {
+                return &descriptors_[i];
+            }
+        }
+
+        return nullptr;
+    }
+
+    /// @brief Creates an instance of a registered type.
+    /// @param type Type identifier to create.
+    /// @param args Arguments forwarded to the selected factory.
+    /// @return Created instance, the fallback instance if configured, or an empty owner.
+    Owned create(std::string_view type, Args... args) const {
+        if (const Descriptor* descriptor = find(type);
+            descriptor && descriptor->create) {
+            return descriptor->create(args...);
+        }
+
+        return fallback_ ? fallback_(args...) : Owned{};
+    }
+
+    const Descriptor* begin() const { return descriptors_; }
+    const Descriptor* end() const { return descriptors_ + count_; }
+    std::size_t size() const { return count_; }
+
+    /// @brief Writes editor metadata for all registered polymorphic types.
+    /// @param writer JSON writer receiving the type metadata.
+    /// @return true if all metadata is written successfully; otherwise false.
+    bool writeTypesMeta(json::Writer& writer) const {
+        return writer.writeArray([&](json::ArrayWriter& types) {
+            for (std::size_t i = 0; i < count_; ++i) {
+                const auto& descriptor = descriptors_[i];
+
+                if (!types.writeObject([&](json::ObjectWriter& entry) {
+                    return entry.write("id", descriptor.id ? descriptor.id : "")
+                        && entry.write("name", descriptor.name ? descriptor.name : "");
+                })) {
+                    return false;
+                }
+            }
+
+            return true;
+        });
+    }
+
+private:
+    const Descriptor* descriptors_ = nullptr;
+    std::size_t count_ = 0;
+    Creator fallback_ = nullptr;
+};
+
+/// @brief Provides polymorphic registry metadata for a type.
+/// @tparam T Type whose registry support is being queried.
+///
+/// Specialize this trait for types that expose polymorphic type metadata.
+template <typename T, typename = void>
+struct MgPolymorphicRegistryTraits {
+    static constexpr bool supported = false;
+
+    static bool getTypesMeta(json::Writer& writer) {
+        return writer.writeArray([](json::ArrayWriter&) {
+            return true;
+        });
+    }
+};
+
+/// @brief Declares a polymorphic registry with no factory arguments.
+#define MG_POLYMORPHIC_REGISTRY(owned_type) \
+    using Registry = MgPolymorphicRegistry<owned_type>; \
+    static const Registry& registry();
+
+/// @brief Declares a polymorphic registry whose factories accept additional arguments.
+#define MG_POLYMORPHIC_REGISTRY_WITH_ARGS(owned_type, ...) \
+    using Registry = MgPolymorphicRegistry<owned_type, __VA_ARGS__>; \
+    static const Registry& registry();
+
 } // namespace mg

--- a/include/multigauge/properties/Property.h
+++ b/include/multigauge/properties/Property.h
@@ -10,26 +10,28 @@
 
 namespace mg {
 
-class PropertyObject;
+class PropertyObject; // Forward declaration
 
+/// @brief Describes a property exposed through the property system.
 struct Property {
+    /// @brief Function used to decode and assign a property value.
     using Setter = bool (*)(PropertyObject*, json::Reader);
-    using Getter = bool (*)(const PropertyObject*, json::Writer&);
-    using ChildGetter = PropertyObject* (*)(PropertyObject*);
-    using ChildGetterConst = const PropertyObject* (*)(const PropertyObject*);
 
-    /// Key used in JSON schema
-    const char* key = nullptr;
-    /// Setter function using json value as input
-    Setter set = nullptr;
-    /// Getter function using json value as output
-    Getter get = nullptr;
-    /// Returns mutable nested PropertyObject for group-like properties, or nullptr.
+    /// @brief Function used to encode a property value.
+    using Getter = bool (*)(const PropertyObject*, json::Writer&);
+
+    /// @brief Function used to access a nested PropertyObject.
+    using ChildGetter = const PropertyObject* (*)(const PropertyObject*);
+
+    const char* key = nullptr; ///< JSON key.
+    Setter set = nullptr; ///< Setter function using json value as input.
+    Getter get = nullptr; ///< Getter function using json value as output.
+    /// Returns a borrowed nested property object, or nullptr when absent.
+    /// The returned object must be owned by the supplied property object.
     ChildGetter getChild = nullptr;
-    /// Returns const nested PropertyObject for group-like properties, or nullptr.
-    ChildGetterConst getChildConst = nullptr;
+
 #if MG_ENABLE_EDITOR_REFLECTION
-    const PropertyMetadata meta;
+    const PropertyMetadata meta; ///< Property metadata.
 
     bool writeBaseMeta(json::ObjectWriter& object) const;
 #endif

--- a/include/multigauge/properties/PropertyBuilder.h
+++ b/include/multigauge/properties/PropertyBuilder.h
@@ -2,6 +2,8 @@
 
 #include <memory>
 #include <optional>
+#include <concepts>
+#include <functional>
 #include <type_traits>
 #include <utility>
 
@@ -17,16 +19,11 @@
 namespace mg {
 
 /// Resolves the parent property-list getter exposed by `MG_PROPS_PARENT`.
-template <typename T, typename = void>
-struct MgPropsParentGetter {
-    static constexpr ::mg::PropertyObject::PropertyList::ParentGetter value = nullptr;
-};
-
-/// Specialization for types that expose `__mg_parent_property_list`.
 template <typename T>
-struct MgPropsParentGetter<T, std::void_t<decltype(&T::__mg_parent_property_list)>> {
-    static constexpr ::mg::PropertyObject::PropertyList::ParentGetter value = &T::__mg_parent_property_list;
-};
+constexpr ::mg::PropertyObject::PropertyList::ParentGetter parentPropertyListGetter() {
+    if constexpr (requires { &T::__mg_parent_property_list; }) return &T::__mg_parent_property_list;
+    return nullptr;
+}
 
 } // namespace mg
 
@@ -61,18 +58,31 @@ using MemberClass = typename MemberPtrTraits<decltype(MemberPtr)>::Class;
 template <auto MemberPtr>
 using MemberType = typename MemberPtrTraits<decltype(MemberPtr)>::Type;
 
+/// A data member of a public `PropertyObject` subtype whose value can be
+/// serialized by the property system.
+template <auto MemberPtr>
+concept PropertyMember = std::is_member_object_pointer_v<decltype(MemberPtr)> &&
+    requires { typename MemberPtrTraits<decltype(MemberPtr)>::Class; typename MemberPtrTraits<decltype(MemberPtr)>::Type; } &&
+    std::derived_from<MemberClass<MemberPtr>, ::mg::PropertyObject>;
+
+/// A no-argument member callback that can be invoked on the member owner.
+template <auto CallbackPtr, typename Owner>
+concept PropertyCallback = std::is_null_pointer_v<decltype(CallbackPtr)> ||
+    requires(Owner& owner) { std::invoke(CallbackPtr, owner); };
+
 //----------[ VALUE ACCESS ]----------//
 
 /// Property setter adapter for a concrete member pointer.
 /// @tparam MemberPtr Pointer to the member being assigned.
 /// @tparam CallbackPtr Optional callback invoked after assignment.
 template <auto MemberPtr, auto CallbackPtr>
+    requires PropertyMember<MemberPtr> && PropertyCallback<CallbackPtr, MemberClass<MemberPtr>>
 bool setMember(::mg::PropertyObject* obj, json::Reader value) {
     using C = MemberClass<MemberPtr>;
     using T = MemberType<MemberPtr>;
     C* self = static_cast<C*>(obj);
 
-    if constexpr (std::is_base_of_v<::mg::PropertyObject, T>) {
+    if constexpr (::mg::PropertyObjectValue<T>) {
     if (!decodeAny<T>(value, self->*MemberPtr)) return false;
     } else {
         T decoded{};
@@ -81,9 +91,7 @@ bool setMember(::mg::PropertyObject* obj, json::Reader value) {
     }
 
     if constexpr (!std::is_same_v<decltype(CallbackPtr), std::nullptr_t>) {
-        using CbClass = MemberClass<CallbackPtr>;
-        auto* cbSelf = static_cast<CbClass*>(obj);
-        (cbSelf->*CallbackPtr)();
+        std::invoke(CallbackPtr, *self);
     }
     return true;
 }
@@ -91,6 +99,7 @@ bool setMember(::mg::PropertyObject* obj, json::Reader value) {
 /// Property getter adapter for a concrete member pointer.
 /// @tparam MemberPtr Pointer to the member being serialized.
 template <auto MemberPtr>
+    requires PropertyMember<MemberPtr>
 bool getMember(const ::mg::PropertyObject* obj, json::Writer& writer) {
     using C = MemberClass<MemberPtr>;
     const C* self = static_cast<const C*>(obj);
@@ -109,8 +118,8 @@ struct ChildObjectTraits {
 };
 
 /// Nested-child support for direct `PropertyObject` members.
-template <typename T>
-struct ChildObjectTraits<T, std::enable_if_t<std::is_base_of_v<::mg::PropertyObject, T>>> {
+template <PropertyObjectValue T>
+struct ChildObjectTraits<T> {
     static constexpr bool supported = true;
 
     static const ::mg::PropertyObject* getConst(const T& value) { return &value; }
@@ -118,8 +127,8 @@ struct ChildObjectTraits<T, std::enable_if_t<std::is_base_of_v<::mg::PropertyObj
 };
 
 /// Nested-child support for owned `PropertyObject` pointers.
-template <typename T>
-struct ChildObjectTraits<std::unique_ptr<T>, std::enable_if_t<std::is_base_of_v<::mg::PropertyObject, T>>> {
+template <PropertyObjectValue T>
+struct ChildObjectTraits<std::unique_ptr<T>> {
     static constexpr bool supported = true;
 
     static const ::mg::PropertyObject* getConst(const std::unique_ptr<T>& value) { return value.get(); }
@@ -127,8 +136,8 @@ struct ChildObjectTraits<std::unique_ptr<T>, std::enable_if_t<std::is_base_of_v<
 };
 
 /// Nested-child support for optional `PropertyObject` members.
-template <typename T>
-struct ChildObjectTraits<std::optional<T>, std::enable_if_t<std::is_base_of_v<::mg::PropertyObject, T>>> {
+template <PropertyObjectValue T>
+struct ChildObjectTraits<std::optional<T>> {
     static constexpr bool supported = true;
 
     static const ::mg::PropertyObject* getConst(const std::optional<T>& value) { return value ? &(*value) : nullptr; }
@@ -140,6 +149,7 @@ struct ChildObjectTraits<std::optional<T>, std::enable_if_t<std::is_base_of_v<::
 
 /// Returns the const child object exposed by a member pointer.
 template <auto MemberPtr>
+    requires PropertyMember<MemberPtr>
 const ::mg::PropertyObject* getChildObjectConst(const ::mg::PropertyObject* obj) {
     using C = MemberClass<MemberPtr>;
     using T = MemberType<MemberPtr>;
@@ -150,7 +160,7 @@ const ::mg::PropertyObject* getChildObjectConst(const ::mg::PropertyObject* obj)
 
 /// Returns the mutable child object exposed by a member pointer.
 template <auto MemberPtr>
-::mg::PropertyObject* getChildObject(::mg::PropertyObject* obj) {
+::mg::PropertyObject* getChildObject(::mg::PropertyObject* obj) requires PropertyMember<MemberPtr> {
     using C = MemberClass<MemberPtr>;
     using T = MemberType<MemberPtr>;
     static_assert(ChildObjectTraits<T>::supported, "Member must expose a PropertyObject child.");
@@ -172,7 +182,8 @@ template <auto MemberPtr>
 /// @param interactableWhen Optional interactability-rule provider for tooling.
 /// @param inspectorVisible Whether the property should appear in inspector metadata.
 template <auto MemberPtr, auto CallbackPtr = nullptr>
-::mg::Property makeProperty(const char* key, const char* name, const char* description, RuleListGetter visibleWhen = nullptr, RuleListGetter interactableWhen = nullptr, bool inspectorVisible = true) {
+::mg::Property makeProperty(const char* key, const char* name, const char* description, RuleListGetter visibleWhen = nullptr, RuleListGetter interactableWhen = nullptr, bool inspectorVisible = true)
+    requires detail::PropertyMember<MemberPtr> && detail::PropertyCallback<CallbackPtr, detail::MemberClass<MemberPtr>> {
     using T = detail::MemberType<MemberPtr>;
 
     ::mg::Property p{};
@@ -194,7 +205,7 @@ template <auto MemberPtr, auto CallbackPtr = nullptr>
     meta.inspectorVisible = inspectorVisible;
     meta.getVisibleWhen = visibleWhen;
     meta.getInteractableWhen = interactableWhen;
-    if constexpr (::mg::HasEnumTraitsV<::mg::EnumTraitsTypeT<T>>) meta.getOptionsMeta = &::mg::enumOptionsMeta<::mg::EnumTraitsTypeT<T>>;
+    if constexpr (::mg::EnumDescribed<::mg::EnumTraitsTypeT<T>>) meta.getOptionsMeta = &::mg::enumOptionsMeta<::mg::EnumTraitsTypeT<T>>;
     if constexpr (::mg::MgPolymorphicRegistryTraits<T>::supported) meta.getTypesMeta = &::mg::MgPolymorphicRegistryTraits<T>::getTypesMeta;
 
     return {p.key, p.set, p.get, p.getChild, p.getChildConst, meta};
@@ -378,6 +389,6 @@ public: \
 /** Ends a `propertyList()` override and returns the static property list. */
 #define MG_PROPS_END() \
         }; \
-        const auto parentGetter = ::mg::MgPropsParentGetter<Self>::value; \
+        const auto parentGetter = ::mg::parentPropertyListGetter<Self>(); \
         return { props, sizeof(props) / sizeof(props[0]), parentGetter }; \
     }

--- a/include/multigauge/properties/PropertyBuilder.h
+++ b/include/multigauge/properties/PropertyBuilder.h
@@ -114,7 +114,6 @@ struct ChildObjectTraits {
     static constexpr bool supported = false;
 
     static const ::mg::PropertyObject* getConst(const T&) { return nullptr; }
-    static ::mg::PropertyObject* getMutable(T&) { return nullptr; }
 };
 
 /// Nested-child support for direct `PropertyObject` members.
@@ -123,7 +122,6 @@ struct ChildObjectTraits<T> {
     static constexpr bool supported = true;
 
     static const ::mg::PropertyObject* getConst(const T& value) { return &value; }
-    static ::mg::PropertyObject* getMutable(T& value) { return &value; }
 };
 
 /// Nested-child support for owned `PropertyObject` pointers.
@@ -132,7 +130,6 @@ struct ChildObjectTraits<std::unique_ptr<T>> {
     static constexpr bool supported = true;
 
     static const ::mg::PropertyObject* getConst(const std::unique_ptr<T>& value) { return value.get(); }
-    static ::mg::PropertyObject* getMutable(std::unique_ptr<T>& value) { return value.get(); }
 };
 
 /// Nested-child support for optional `PropertyObject` members.
@@ -141,31 +138,17 @@ struct ChildObjectTraits<std::optional<T>> {
     static constexpr bool supported = true;
 
     static const ::mg::PropertyObject* getConst(const std::optional<T>& value) { return value ? &(*value) : nullptr; }
-
-    static ::mg::PropertyObject* getMutable(std::optional<T>& value) {
-        return value ? &(*value) : nullptr;
-    }
 };
 
-/// Returns the const child object exposed by a member pointer.
+/// Returns the child object exposed by a member pointer.
 template <auto MemberPtr>
     requires PropertyMember<MemberPtr>
-const ::mg::PropertyObject* getChildObjectConst(const ::mg::PropertyObject* obj) {
+const ::mg::PropertyObject* getChildObject(const ::mg::PropertyObject* obj) {
     using C = MemberClass<MemberPtr>;
     using T = MemberType<MemberPtr>;
     static_assert(ChildObjectTraits<T>::supported, "Member must expose a PropertyObject child.");
     const C* self = static_cast<const C*>(obj);
     return ChildObjectTraits<T>::getConst(self->*MemberPtr);
-}
-
-/// Returns the mutable child object exposed by a member pointer.
-template <auto MemberPtr>
-::mg::PropertyObject* getChildObject(::mg::PropertyObject* obj) requires PropertyMember<MemberPtr> {
-    using C = MemberClass<MemberPtr>;
-    using T = MemberType<MemberPtr>;
-    static_assert(ChildObjectTraits<T>::supported, "Member must expose a PropertyObject child.");
-    C* self = static_cast<C*>(obj);
-    return ChildObjectTraits<T>::getMutable(self->*MemberPtr);
 }
 
 } // namespace detail
@@ -193,7 +176,6 @@ template <auto MemberPtr, auto CallbackPtr = nullptr>
 
     if constexpr (detail::ChildObjectTraits<T>::supported) {
         p.getChild = &detail::getChildObject<MemberPtr>;
-        p.getChildConst = &detail::getChildObjectConst<MemberPtr>;
     }
 
 #if MG_ENABLE_EDITOR_REFLECTION
@@ -208,7 +190,7 @@ template <auto MemberPtr, auto CallbackPtr = nullptr>
     if constexpr (::mg::EnumDescribed<::mg::EnumTraitsTypeT<T>>) meta.getOptionsMeta = &::mg::enumOptionsMeta<::mg::EnumTraitsTypeT<T>>;
     if constexpr (::mg::MgPolymorphicRegistryTraits<T>::supported) meta.getTypesMeta = &::mg::MgPolymorphicRegistryTraits<T>::getTypesMeta;
 
-    return {p.key, p.set, p.get, p.getChild, p.getChildConst, meta};
+    return {p.key, p.set, p.get, p.getChild, meta};
 #else
     (void)name; (void)description; (void)visibleWhen; (void)interactableWhen; (void)inspectorVisible;
     return p;
@@ -234,10 +216,10 @@ inline ::mg::Property makeCustomProperty(const char* key, const char* name, cons
     meta.getVisibleWhen = visibleWhen;
     meta.getInteractableWhen = interactableWhen;
 
-    return {key, set, get, nullptr, nullptr, meta};
+    return {key, set, get, nullptr, meta};
 #else
     (void)name; (void)description; (void)visibleWhen; (void)interactableWhen; (void)inspectorVisible;
-    return {key, set, get, nullptr, nullptr};
+    return {key, set, get, nullptr};
 #endif
 }
 

--- a/include/multigauge/properties/PropertyCodec.h
+++ b/include/multigauge/properties/PropertyCodec.h
@@ -2,43 +2,92 @@
 
 #include <multigauge/properties/Codec.h>
 
+#include <type_traits>
+
 namespace mg {
 
 class PropertyObject;
-template <typename T, typename = void> struct PolymorphicOwnedTraits { static constexpr bool supported = false; };
 
+/// @brief A publicly derived PropertyObject suitable for inline property storage.
+template <typename T>
+concept PropertyObjectValue =
+    std::derived_from<std::remove_cv_t<T>, PropertyObject>;
+
+/// @brief Decodes an owning polymorphic PropertyObject using the base type registry.
+/// @tparam Base Base PropertyObject type providing the registry.
+/// @tparam Owned Owning pointer-like type receiving the decoded object.
+/// @param value JSON value to decode.
+/// @param out Destination receiving the decoded object, or null for a JSON null value.
+/// @return true if decoding succeeds; otherwise false.
 template <typename Base, typename Owned>
+    requires std::derived_from<Base, PropertyObject>
 inline bool decodePolymorphicOwned(json::Reader value, Owned& out) {
-    if (value.isNull()) { out = nullptr; return true; }
+    if (value.isNull()) {
+        out = nullptr;
+        return true;
+    }
+
     if (!value.isObject()) return false;
+
     std::string_view typeView;
     (void)value.member("type").read(typeView);
+
     Owned decoded = Base::registry().create(typeView);
     if (!decoded || !decoded->loadProperties(value)) return false;
+
     out = std::move(decoded);
     return true;
 }
 
+/// @brief Encodes an owning polymorphic PropertyObject.
+/// @tparam Owned Owning pointer-like type containing the object to encode.
+/// @param writer JSON writer receiving the encoded value.
+/// @param value Object to encode, or an empty owner to encode as JSON null.
+/// @return true if encoding succeeds; otherwise false.
 template <typename Owned>
 inline bool encodePolymorphicOwned(json::Writer& writer, const Owned& value) {
     return value ? value->saveProperties(writer) : writer.null();
 }
 
+/// @brief Decodes a value using its Codec or PropertyObject serialization.
+/// @tparam T Type to decode.
+/// @param value JSON value to decode.
+/// @param out Destination receiving the decoded value.
+/// @return true if decoding succeeds; otherwise false.
 template <typename T>
 inline bool decodeAny(json::Reader value, T& out) {
-    if constexpr (HasCodecV<T>) { if (Codec<T>::decode(value, out)) return true; }
-    if constexpr (PolymorphicOwnedTraits<T>::supported) { using Base = typename PolymorphicOwnedTraits<T>::Base; if (decodePolymorphicOwned<Base>(value, out)) return true; }
-    if constexpr (std::is_base_of_v<PropertyObject, T>) { return value.isObject() && out.loadProperties(value); }
-    static_assert(HasCodecV<T> || std::is_base_of_v<PropertyObject, T> || PolymorphicOwnedTraits<T>::supported, "Type must have Codec<T>, be a PropertyObject, or use the polymorphic owned path.");
+    static_assert(
+        CodecFor<T> || PropertyObjectValue<T>,
+        "Type must have a valid Codec<T> or be a publicly derived PropertyObject."
+    );
+
+    if constexpr (CodecFor<T>) {
+        if (Codec<T>::decode(value, out)) return true;
+    }
+
+    if constexpr (PropertyObjectValue<T>) return value.isObject() && out.loadProperties(value);
+
     return false;
 }
 
+/// @brief Encodes a value using its Codec or PropertyObject serialization.
+/// @tparam T Type to encode.
+/// @param writer JSON writer receiving the encoded value.
+/// @param value Value to encode.
+/// @return true if encoding succeeds; otherwise false.
 template <typename T>
 inline bool encodeAny(json::Writer& writer, const T& value) {
-    if constexpr (HasCodecV<T>) { if (Codec<T>::encode(writer, value)) return true; }
-    if constexpr (PolymorphicOwnedTraits<T>::supported) { if (encodePolymorphicOwned(writer, value)) return true; }
-    if constexpr (std::is_base_of_v<PropertyObject, T>) return value.saveProperties(writer);
-    static_assert(HasCodecV<T> || std::is_base_of_v<PropertyObject, T> || PolymorphicOwnedTraits<T>::supported, "Type must have Codec<T>, be a PropertyObject, or use the polymorphic owned path.");
+    static_assert(
+        CodecFor<T> || PropertyObjectValue<T>,
+        "Type must have a valid Codec<T> or be a publicly derived PropertyObject."
+    );
+
+    if constexpr (CodecFor<T>) {
+        if (Codec<T>::encode(writer, value)) return true;
+    }
+
+    if constexpr (PropertyObjectValue<T>) return value.saveProperties(writer);
+
     return false;
 }
 

--- a/include/multigauge/properties/PropertyObject.h
+++ b/include/multigauge/properties/PropertyObject.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <concepts>
 #include <string>
 #include <vector>
 
@@ -40,6 +41,7 @@ class PropertyObject {
 
             /// Iterates this property list and every parent list in order.
             template <typename Fn>
+                requires std::invocable<Fn&, const Property&>
             void forEach(const PropertyObject* self, Fn&& fn) const {
                 for (PropertyList pl = *this; pl.valid(); pl = next(self, pl)) {
                     if (!pl.props || pl.count == 0) continue;

--- a/include/multigauge/properties/WidgetTraits.h
+++ b/include/multigauge/properties/WidgetTraits.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <concepts>
 #include <type_traits>
 #include <vector>
 
@@ -27,7 +28,8 @@ struct MgPropNullableTraits {
 };
 
 template <typename T>
-struct MgPropWidgetTraits<T, std::enable_if_t<HasEnumTraitsV<EnumTraitsTypeT<T>>>> {
+    requires EnumDescribed<EnumTraitsTypeT<T>>
+struct MgPropWidgetTraits<T> {
     static constexpr const char* value = "select";
 };
 
@@ -39,7 +41,8 @@ MG_EDITOR_WIDGET(bool, "boolean")
 MG_EDITOR_WIDGET(graphics::rgba, "color-selector")
 
 template <typename T>
-struct MgPropWidgetTraits<T, std::enable_if_t<std::is_arithmetic_v<T> && !std::is_same_v<T, bool>>> {
+    requires (std::is_arithmetic_v<T> && !std::is_same_v<T, bool>)
+struct MgPropWidgetTraits<T> {
     static constexpr const char* value = "number";
 };
 
@@ -61,7 +64,8 @@ struct MgPropNullableTraits<std::optional<T>> {
 };
 
 template <typename T>
-struct MgPropWidgetTraits<T, std::enable_if_t<std::is_base_of_v<PropertyObject, T>>> {
+    requires std::derived_from<T, PropertyObject>
+struct MgPropWidgetTraits<T> {
     static constexpr const char* value = "group";
 };
 

--- a/include/multigauge/properties/codecs/StandardCodecs.h
+++ b/include/multigauge/properties/codecs/StandardCodecs.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <multigauge/properties/Codec.h>
+
+namespace mg {
+
+CODEC_BEGIN(bool)
+    DECODE() { return v.read(out); }
+    ENCODE() { return out.write(v); }
+CODEC_END()
+
+CODEC_BEGIN(int)
+    DECODE() { std::int64_t decoded; if (!v.read(decoded) || decoded < std::numeric_limits<int>::min() || decoded > std::numeric_limits<int>::max()) return false; out = static_cast<int>(decoded); return true; }
+    ENCODE() { return out.write(v); }
+CODEC_END()
+
+CODEC_BEGIN(std::int8_t)
+    DECODE() { std::int64_t decoded; if (!v.read(decoded) || decoded < std::numeric_limits<std::int8_t>::min() || decoded > std::numeric_limits<std::int8_t>::max()) return false; out = static_cast<std::int8_t>(decoded); return true; }
+    ENCODE() { return out.write(static_cast<int>(v)); }
+CODEC_END()
+
+CODEC_BEGIN(float)
+    DECODE() { double decoded; if (!v.read(decoded) || !std::isfinite(decoded) || decoded < -std::numeric_limits<float>::max() || decoded > std::numeric_limits<float>::max()) return false; out = static_cast<float>(decoded); return true; }
+    ENCODE() { return out.write(v); }
+CODEC_END()
+
+CODEC_BEGIN(std::string)
+    DECODE() { std::string_view decoded; if (!v.read(decoded)) return false; out.assign(decoded); return true; }
+    ENCODE() { return out.write(v); }
+CODEC_END()
+
+CODEC_BEGIN_TPARAMS(typename T, std::optional<T>)
+    DECODE() { if (v.isNull()) { out.reset(); return true; } T decoded{}; if (!decodeAny(v, decoded)) return false; out = std::move(decoded); return true; }
+    ENCODE() { return v ? encodeAny(out, *v) : out.null(); }
+CODEC_END()
+
+CODEC_BEGIN_TPARAMS(typename T, std::vector<T>)
+    DECODE() { if (!v.isArray()) return false; CodecType decoded; decoded.reserve(v.size()); for (std::size_t i = 0; i < v.size(); ++i) { T element{}; if (!decodeAny(v.element(i), element)) return false; decoded.push_back(std::move(element)); } out = std::move(decoded); return true; }
+    ENCODE() { return out.writeArray([&](json::ArrayWriter&) { for (const auto& element : v) { if (!encodeAny(out, element)) return false; } return true; }); }
+CODEC_END()
+
+} // namespace mg

--- a/include/multigauge/properties/meta/PropertyMetadata.h
+++ b/include/multigauge/properties/meta/PropertyMetadata.h
@@ -5,15 +5,9 @@
 
 namespace mg {
 
-class PropertyObject;
+class PropertyObject; // Forward declaration
 
-/// Editor-facing metadata for a property exposed through the property system
-/// 
-/// Describes how a property should appear and behave in tooling. This currently
-/// includes display labels, widget types, optional choices, and conditional UI rules.
-///
-/// Metadata does not store the property's runtime value and does not enforce runtime
-/// behavior. It is only used by editors/tooling that require it for interfaces.
+/// @brief Editor-facing metadata for a property exposed through the property system.
 struct PropertyMetadata {
     using OptionsGetter = bool (*)(json::Writer&);
     using TypeListGetter = bool (*)(json::Writer&);
@@ -21,30 +15,21 @@ struct PropertyMetadata {
 
     //----------[ GENERIC ]----------//
 
-    /// Display name used in editor
-    const char* name = nullptr;
-    ///  Brief description used in editor
-    const char* description = nullptr;
-    /// Widget type to display for UI in editor
-    const char* widget = nullptr;
+    const char* name = nullptr;        ///< Display name shown in the editor.
+    const char* description = nullptr; ///< Brief description shown in the editor.
+    const char* widget = nullptr;      ///< Editor widget used to edit the property.
 
     //----------[ INTERACTION ]----------//
 
-    /// Whether the editor should treat this property as nullable.
-    bool nullable = false;
-    /// Whether this property should be listed in inspector metadata.
-    bool inspectorVisible = true;
-    /// Declarative visibility rules for the editor UI.
-    RuleListGetter getVisibleWhen = nullptr;
-    /// Declarative interactability rules for the editor UI.
-    RuleListGetter getInteractableWhen = nullptr;
+    bool nullable = false;                  ///< Whether the property may be set to null.
+    bool inspectorVisible = true;           ///< Whether the property is shown in the editor inspector.
+    RuleListGetter getVisibleWhen = nullptr;      ///< Retrieves rules controlling property visibility.
+    RuleListGetter getInteractableWhen = nullptr; ///< Retrieves rules controlling property interactability.
 
-    //----------[  ]----------//
+    //----------[ SELECTION ]----------//
 
-    /// Returns dropdown/select options metadata when available.
-    OptionsGetter getOptionsMeta = nullptr;
-    /// Returns available polymorphic types metadata when available.
-    TypeListGetter getTypesMeta = nullptr;
+    OptionsGetter getOptionsMeta = nullptr; ///< Retrieves metadata for available selection options.
+    TypeListGetter getTypesMeta = nullptr;  ///< Retrieves metadata for available polymorphic types.
 };
 
 }

--- a/include/multigauge/properties/meta/Rules.h
+++ b/include/multigauge/properties/meta/Rules.h
@@ -5,6 +5,31 @@
 #include <initializer_list>
 
 namespace mg::rules {
-bool writeRule(json::Writer& writer, const char* path, const char* op, const char* value);
-bool writeRule(json::Writer& writer, const char* path, const char* op, std::initializer_list<const char*> values);
+
+/// @brief Writes a property rule with a single comparison value.
+/// @param writer JSON writer receiving the rule object.
+/// @param path Property path evaluated by the rule.
+/// @param op Rule operator to apply.
+/// @param value Value used by the rule.
+/// @return true if the rule was written successfully; otherwise false.
+bool writeRule(
+    json::Writer& writer,
+    const char* path,
+    const char* op,
+    const char* value
+);
+
+/// @brief Writes a property rule with multiple comparison values.
+/// @param writer JSON writer receiving the rule object.
+/// @param path Property path evaluated by the rule.
+/// @param op Rule operator to apply.
+/// @param values Values used by the rule.
+/// @return true if the rule was written successfully; otherwise false.
+bool writeRule(
+    json::Writer& writer,
+    const char* path,
+    const char* op,
+    std::initializer_list<const char*> values
+);
+
 } // namespace mg::rules

--- a/include/multigauge/value/ValueView.h
+++ b/include/multigauge/value/ValueView.h
@@ -80,7 +80,7 @@ CODEC_BEGIN(ValueView)
         std::string_view id;
 
         if (v.read(id)) {
-            out = CodecType(id);
+            out = ValueView(id);
             return static_cast<bool>(out.value_);
         }
 

--- a/src/gauge/Element.cpp
+++ b/src/gauge/Element.cpp
@@ -42,7 +42,7 @@ namespace {
 }
 
 const Element::Registry& Element::registry() {
-    static const Registry registry(ELEMENT_TYPES, sizeof(ELEMENT_TYPES) / sizeof(ELEMENT_TYPES[0]), &createDefaultElement);
+    static const Registry registry(ELEMENT_TYPES, &createDefaultElement);
     return registry;
 }
 

--- a/src/graphics/colors/Color.cpp
+++ b/src/graphics/colors/Color.cpp
@@ -36,7 +36,7 @@ Color::Color() noexcept : id_(allocateColorId()) {}
 Color::Color(const Color&) noexcept : id_(allocateColorId()) {}
 
 const Color::Registry& Color::registry() {
-    static const Registry registry(colorTypes, sizeof(colorTypes) / sizeof(colorTypes[0]), &createDefaultColor);
+    static const Registry registry(colorTypes, &createDefaultColor);
     return registry;
 }
 

--- a/src/properties/PropertyObject.cpp
+++ b/src/properties/PropertyObject.cpp
@@ -68,14 +68,14 @@ bool PropertyObject::writePropertyMeta(json::Writer& writer, const Property& pro
 #else
     return writer.writeObject([&](json::ObjectWriter& object) {
         if (!prop.writeBaseMeta(object)) return false;
-        if (prop.getChildConst) {
+        if (prop.getChild) {
             if (prop.meta.getTypesMeta && !object.writeObject("types", [&](json::ObjectWriter& types) {
-                const PropertyObject* child = prop.getChildConst(this);
+                const PropertyObject* child = prop.getChild(this);
                 if (child && child->typeId()) { if (!types.write("current", child->typeId())) return false; }
                 else if (!types.writeValue("current", [](json::Writer& value) { return value.null(); })) return false;
                 return types.writeValue("all", prop.meta.getTypesMeta);
             })) return false;
-            const PropertyObject* child = prop.getChildConst(this);
+            const PropertyObject* child = prop.getChild(this);
             return object.writeArray("properties", [&](json::ArrayWriter& properties) {
                 if (!child) return true;
                 return child->writePropertiesMeta(properties.writer());
@@ -95,13 +95,13 @@ std::vector<std::string> PropertyObject::splitPath(const std::string& path) {
 
 bool PropertyObject::resolvePath(const std::string& path, PropertyObject*& owner, const Property*& prop) {
     owner = nullptr; prop = nullptr; const auto parts = splitPath(path); if (parts.empty()) return false; PropertyObject* current = this;
-    for (std::size_t i = 0; i < parts.size(); ++i) { const Property* found = current->findProperty(parts[i].c_str()); if (!found) return false; if (i + 1 == parts.size()) { owner = current; prop = found; return true; } if (!found->getChild || !(current = found->getChild(current))) return false; }
+    for (std::size_t i = 0; i < parts.size(); ++i) { const Property* found = current->findProperty(parts[i].c_str()); if (!found) return false; if (i + 1 == parts.size()) { owner = current; prop = found; return true; } const PropertyObject* child = found->getChild ? found->getChild(current) : nullptr; if (!child) return false; current = const_cast<PropertyObject*>(child); }
     return false;
 }
 
 bool PropertyObject::resolvePath(const std::string& path, const PropertyObject*& owner, const Property*& prop) const {
     owner = nullptr; prop = nullptr; const auto parts = splitPath(path); if (parts.empty()) return false; const PropertyObject* current = this;
-    for (std::size_t i = 0; i < parts.size(); ++i) { const Property* found = current->findProperty(parts[i].c_str()); if (!found) return false; if (i + 1 == parts.size()) { owner = current; prop = found; return true; } if (!found->getChildConst || !(current = found->getChildConst(current))) return false; }
+    for (std::size_t i = 0; i < parts.size(); ++i) { const Property* found = current->findProperty(parts[i].c_str()); if (!found) return false; if (i + 1 == parts.size()) { owner = current; prop = found; return true; } if (!found->getChild || !(current = found->getChild(current))) return false; }
     return false;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(multigauge_core_tests
   test_value_view.cpp
   test_value_embed.cpp
   test_properties.cpp
+  test_polymorphic_registry.cpp
   test_colors.cpp
 )
 

--- a/tests/test_polymorphic_registry.cpp
+++ b/tests/test_polymorphic_registry.cpp
@@ -1,0 +1,30 @@
+#include <doctest/doctest.h>
+
+#include <multigauge/graphics/colors/Color.h>
+
+#include <string_view>
+
+namespace {
+
+template <typename Registry>
+void checkRegistry(const Registry& registry) {
+    REQUIRE(registry.size() > 0);
+
+    for (const auto& descriptor : registry) {
+        REQUIRE(descriptor.id != nullptr);
+        CHECK(std::string_view(descriptor.id).size() > 0);
+        CHECK(descriptor.create != nullptr);
+        CHECK(registry.find(descriptor.id) == &descriptor);
+
+        for (const auto& other : registry) {
+            if (&descriptor == &other) continue;
+            CHECK(std::string_view(descriptor.id) != std::string_view(other.id));
+        }
+    }
+}
+
+} // namespace
+
+TEST_CASE("polymorphic registries expose unique, constructible type descriptors") {
+    checkRegistry(mg::graphics::Color::registry());
+}

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -24,6 +24,9 @@ struct Parent final : mg::PropertyObject {
     MG_PROPS_END()
 };
 
+static_assert(mg::CodecFor<int>);
+static_assert(mg::PropertyObjectValue<Child>);
+
 mg::json::Document objectWithValue(std::string_view json) {
     return mg::json::parse(json);
 }

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -61,6 +61,11 @@ TEST_CASE("properties serialize, resolve paths, and represent nullable children"
     CHECK(owner == &parent.child);
     CHECK(property == parent.child.findProperty("value"));
     CHECK_FALSE(parent.resolvePath("optionalChild.value", owner, property));
+
+    const Parent& constParent = parent;
+    const mg::PropertyObject* constOwner = nullptr;
+    REQUIRE(constParent.resolvePath("child.value", constOwner, property));
+    CHECK(constOwner == &parent.child);
 }
 
 TEST_CASE("property metadata respects the reflection configuration") {


### PR DESCRIPTION
## What changed?

Refactored the property serialization/reflection layer to use c++20 concepts and simpler descriptor plumbing
- Replaced codec and enum SFINAE detection traits with CodecFor and EnumDescribed
- Constrained property builders, child-property handling, widget traits, and property-list iteration.
- Simplified nested-property access to a single const child accessor.
- Moved standard codecs into `properties/codecs/StandardCodecs.h`. `Codec.h` includes it to preserve normal include behavior.
- Reworked polymorphic registries to use `std::span<const Descriptor>` and added `[[nodiscard]]` annotations.
- Removed unused generic helpers and uaotmatic trait-driven polymorphic codec dispatch.
- Added documentation and focused registry/property tests.

## Why?
The prior property system relied heavily on SFINAE, bool "supported" traits, duplicate mutable/const child accessors, and pointer+count registry storage. This refactor makes contracts explicit at compile time, improves diagnostics at property declarations, reduces descriptor storage, and removes unused abstraction paths.

## Refactoring notes

- `CodecFor<T>` requires exact `bool decode(Reader, T&)` and `bool encode(Writer&, const T&)` members.
- `EnumDescribed<T>` replaces enum-options detection traits.
- Property builders now validate property member ptrs and callbacks with concepts: callbacks use `std::invoke`.
- `Property::getChild` is now the single nested-child accessor no more mutable override. Mutable paths can use `const_cast`.
- Registry descriptors are passed as `std::span`, eliminating mismatched pointer/count construction.
- `decodePolymorphicOwned` and `enodePolymorphicOwned` remain as explicit helpers, only unused automatic trait-based dispatch was removed.

## Behavior impact

Serialized keys, type IDs, property paths, and editor metadata behavior are preserved.

Intentional source/API changes:
- Removed `HasCodec`, `HasCodecV`, `HasEnumTraits`, `HasEnumTraitsV`, and `mg_remove_cvref`.
- Removed automatic `PolymorphicOwnedTraits` dispatch.
- `Property` now has one child accessor instead of separate mutable and const accessors.
- The old `set(json::Reader, key, out)` codec helper was removed.
- Standard codec definitions moved to `properties/codecs/StandardCodecs.h`, but including `Codec.h` still exposes them.

## Testing

- Added tests for const and mutable nested property-path resolution
- Added polymorphic-registry integrity coverage for non-empty unique IDs, valid factories, and lookup consistency.

## Migration notes

Downstream code using removed detection traits should use `CodecFor<T>` or `EnumDescribed<T>`.

Custom `Property` descriptors must provide the single const child accessor and ensure it returns a borrowed child owned by the supplied object.

## Checklist

* [X] This PR is limited to one logical refactor
* [X] Existing behavior is preserved unless explicitly documented
* [X] Public APIs, configuration, serialization, or documentation were updated if needed
* [X] Tests were added or updated where responsibilities or boundaries changed
* [X] No debugging code, temporary files, or unrelated changes are included