### PR TITLE
Feature/save property members

### DIFF
--- a/include/multigauge/properties/PropertyObject.h
+++ b/include/multigauge/properties/PropertyObject.h
@@ -72,6 +72,11 @@ class PropertyObject {
         /// Serializes all exposed properties into a JSON object.
         bool saveProperties(json::Writer& writer) const;
 
+        /// Serializes the type identifier and all exposed properties into an
+        /// already-open JSON object. This composes property objects with
+        /// container-owned fields such as a gauge face's child hierarchy.
+        bool savePropertyMembers(json::ObjectWriter& object) const;
+
         /// Builds editor metadata for every visible property on this object.
         bool writePropertiesMeta(json::Writer& writer) const;
 

--- a/src/properties/PropertyObject.cpp
+++ b/src/properties/PropertyObject.cpp
@@ -35,15 +35,17 @@ bool PropertyObject::loadProperties(json::Reader object) {
 }
 
 bool PropertyObject::saveProperties(json::Writer& writer) const {
-    return writer.writeObject([&](json::ObjectWriter& object) {
-        if (const char* type = typeId(); type && !object.write(TYPE_KEY, type)) return false;
-        bool success = true;
-        propertyList().forEach(this, [&](const Property& property) {
-            if (!success || !property.key || !property.get || findProperty(property.key) != &property) return;
-            success = object.writeValue(property.key, [&](json::Writer& value) { return property.get(this, value); });
-        });
-        return success;
+    return writer.writeObject([&](json::ObjectWriter& object) { return savePropertyMembers(object); });
+}
+
+bool PropertyObject::savePropertyMembers(json::ObjectWriter& object) const {
+    if (const char* type = typeId(); type && !object.write(TYPE_KEY, type)) return false;
+    bool success = true;
+    propertyList().forEach(this, [&](const Property& property) {
+        if (!success || !property.key || !property.get || findProperty(property.key) != &property) return;
+        success = object.writeValue(property.key, [&](json::Writer& value) { return property.get(this, value); });
     });
+    return success;
 }
 
 bool PropertyObject::writePropertiesMeta(json::Writer& writer) const {

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -24,6 +24,14 @@ struct Parent final : mg::PropertyObject {
     MG_PROPS_END()
 };
 
+struct TypedChild final : mg::PropertyObject {
+    int value = 11;
+    MG_TYPE_ID("test-child")
+    MG_PROPS_BEGIN()
+        MG_PROP(value, "value", "Value", "Test value.")
+    MG_PROPS_END()
+};
+
 static_assert(mg::CodecFor<int>);
 static_assert(mg::PropertyObjectValue<Child>);
 
@@ -66,6 +74,25 @@ TEST_CASE("properties serialize, resolve paths, and represent nullable children"
     const mg::PropertyObject* constOwner = nullptr;
     REQUIRE(constParent.resolvePath("child.value", constOwner, property));
     CHECK(constOwner == &parent.child);
+}
+
+TEST_CASE("properties serialize members into an existing object") {
+    TypedChild child;
+    mg::json::Document encoded = mg::json::object();
+    mg::json::Writer writer = encoded.writer();
+    REQUIRE(writer.writeObject([&](mg::json::ObjectWriter& object) {
+        return object.write("owner", "container") && child.savePropertyMembers(object);
+    }));
+
+    std::string_view type;
+    std::string_view owner;
+    std::int64_t value = 0;
+    REQUIRE(encoded.root().member("type").read(type));
+    REQUIRE(encoded.root().member("owner").read(owner));
+    REQUIRE(encoded.root().member("value").read(value));
+    CHECK(type == "test-child");
+    CHECK(owner == "container");
+    CHECK(value == 11);
 }
 
 TEST_CASE("property metadata respects the reflection configuration") {


### PR DESCRIPTION
## What changed?

Added `PropertyObject::savePropertyMembers(json::ObjectWriter&)`, allowing a property object to write its type identifier and exposed properties into an object the caller has already opened.

`saveProperties` now delegates to this method, preserving its existing behavior.

## Why?

Container formats sometimes need to combine a property object's serialized fields with container-owned fields in one JSON object, for example, hierarchy or relationship data. Previously, callers had to either add an unnecessary nested object or duplicate property serialization logic.

## Implementation notes

`savePropertyMembers` emits the same `type` field and registered property members as `saveProperties`, but does not open or close the surrounding JSON object. Callers own the object and any additional fields they add.

## Testing

- Built the `multigauge_core_tests` target.
- Ran the focused property suite:

  `multigauge_core_tests.exe --test-case=properties* --no-skip`

  Result: 3 test cases passed, 21 assertions passed.

- Added coverage that verifies property members and container-owned fields serialize together in one JSON object.

## Checklist

- [x] This PR is limited to one logical feature or change
- [x] Public APIs, configuration, or documentation were updated if needed.
- [x] No debugging code, temporary files, or unrelated changes are included