### PR TITLE
Fix Json Declaration Order

### DIFF
--- a/include/multigauge/json/Json.h
+++ b/include/multigauge/json/Json.h
@@ -98,20 +98,10 @@ public:
     bool write(Reader value) noexcept;
 
     template <typename Fn>
-    bool writeObject(Fn&& fn) {
-        if (!beginObject()) return false;
-        ObjectWriter object(*this);
-        const bool result = std::forward<Fn>(fn)(object);
-        return endObject() && result;
-    }
+    bool writeObject(Fn&& fn);
 
     template <typename Fn>
-    bool writeArray(Fn&& fn) {
-        if (!beginArray()) return false;
-        ArrayWriter array(*this);
-        const bool result = std::forward<Fn>(fn)(array);
-        return endArray() && result;
-    }
+    bool writeArray(Fn&& fn);
 
 private:
     friend class ObjectWriter;
@@ -174,6 +164,22 @@ public:
 private:
     Writer& writer_;
 };
+
+template <typename Fn>
+bool Writer::writeObject(Fn&& fn) {
+    if (!beginObject()) return false;
+    ObjectWriter object(*this);
+    const bool result = std::forward<Fn>(fn)(object);
+    return endObject() && result;
+}
+
+template <typename Fn>
+bool Writer::writeArray(Fn&& fn) {
+    if (!beginArray()) return false;
+    ArrayWriter array(*this);
+    const bool result = std::forward<Fn>(fn)(array);
+    return endArray() && result;
+}
 
 /// Opaque, move-only owned JSON document supplied by the selected backend.
 struct DocumentBackend {


### PR DESCRIPTION
## What was fixed?

Fixed a Clang compilation failure in `mg::json::Writer` when including `Json.h`.

The affected APIs were `Writer::writeObject` and `Writer::writeArray`.

## Why?

The JSON writer header failed to compile with Clang because its inline template bodies created `ObjectWriter` and `ArrayWriter` instances before those types were fully defined.

This blocked consumers from building the core library even though the APIs themselves were valid and already covered by JSON writer tests.

## Root cause

`ObjectWriter` and `ArrayWriter` were only forward-declared when the `Writer` class defined the `writeObject` and `writeArray` template bodies. Constructing an incomplete type is invalid.

## Fix

Changed `Writer::writeObject` and `Writer::writeArray` to declarations inside `Writer`, then defined the templates after `ObjectWriter` and `ArrayWriter` are complete.

The public API and JSON output behavior are unchanged.

## Testing

- Built the relevant target:

  `cmake --build build-inline-nodehandle --target multigauge_core_tests`

- Ran the relevant test suite:

  `multigauge_core_tests.exe --test-case=JSON* --no-skip`

  Result: 2 test cases passed, 14 assertions passed.

- Existing JSON writer coverage verifies:
  - Nested object and array writes continue to work.
  - JSON values can still be copied into writer output.
  - Strict JSON reader behavior is unchanged.

## Checklist

- [x] This PR is limited to one logical fix
- [x] A regression test was added or updated where appropriate
- [x] Public APIs, configuration, or documentation were updated if needed
- [x] No debugging code, temporary files, or unrelated changes are included