### PR TITLE
Make Sensor Manager Owning of Sensor Providers

### DIFF
--- a/include/multigauge/sensor/Manager.h
+++ b/include/multigauge/sensor/Manager.h
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -39,12 +40,12 @@ public:
 
     //----------[ PROVIDERS ]----------//
 
-    /// @brief Registers a host-owned provider and applies its saved configuration.
-    /// @param provider The provider to borrow.
+    /// @brief Takes ownership of a provider and applies its saved configuration.
+    /// @param provider The provider to register. Ownership is retained only on success.
     /// @return True when the provider is configured and registered.
-    [[nodiscard]] bool registerProvider(Provider& provider);
+    [[nodiscard]] bool registerProvider(std::unique_ptr<Provider> provider);
 
-    /// @brief Unregisters a provider while retaining its persisted configuration.
+    /// @brief Destroys a registered provider while retaining its persisted configuration.
     /// @param providerId The stable provider identifier.
     /// @return True when a registered provider was removed.
     [[nodiscard]] bool unregisterProvider(std::string_view providerId);
@@ -164,6 +165,7 @@ private:
     
     io::FileSystem& fs_;
     std::string dataRoot_;
+    std::vector<std::unique_ptr<Provider>> ownedProviders_;
     Registry registry_;
     std::vector<ProviderConfig> providers_;
     std::vector<BindingRuntime> bindings_;

--- a/src/sensor/Manager.cpp
+++ b/src/sensor/Manager.cpp
@@ -152,23 +152,43 @@ bool Manager::writeDocument(json::Writer & w) const {
     });
 }
 
-bool Manager::registerProvider(Provider & p) {
-    if (registry_.findProvider(p.id())) return false;
-    auto * c = providerConfig(p.id());
+bool Manager::registerProvider(std::unique_ptr<Provider> p) {
+    if (!p || registry_.findProvider(p->id())) return false;
+    auto * c = providerConfig(p->id());
+    bool addedConfig = false;
     if (!c) {
-        if (providers_.size() >= Registry::MaxProviders || !id(p.id()) || !id(p.type())) return false;
+        if (providers_.size() >= Registry::MaxProviders || !id(p->id()) || !id(p->type())) return false;
         providers_.push_back({
-            std::string(p.id()),
-            std::string(p.type())
+            std::string(p->id()),
+            std::string(p->type())
         });
-        c = & providers_.back();
-        dirty_ = true;
+        c = &providers_.back();
+        addedConfig = true;
     }
-    return c -> type == p.type() && p.loadConfiguration(c -> config.root()) && registry_.registerProvider(p);
+    if (c->type != p->type() || !p->loadConfiguration(c->config.root())) {
+        if (addedConfig) providers_.pop_back();
+        return false;
+    }
+
+    ownedProviders_.push_back(std::move(p));
+    Provider& registered = *ownedProviders_.back();
+    if (!registry_.registerProvider(registered)) {
+        ownedProviders_.pop_back();
+        if (addedConfig) providers_.pop_back();
+        return false;
+    }
+
+    dirty_ = dirty_ || addedConfig;
+    return true;
 }
 
 bool Manager::unregisterProvider(std::string_view i) {
-    return registry_.unregisterProvider(i);
+    const auto provider = std::find_if(ownedProviders_.begin(), ownedProviders_.end(), [i](const auto& item) {
+        return item->id() == i;
+    });
+    if (provider == ownedProviders_.end() || !registry_.unregisterProvider(i)) return false;
+    ownedProviders_.erase(provider);
+    return true;
 }
 
 const Provider * Manager::findProvider(std::string_view i) const noexcept {

--- a/tests/test_sensors.cpp
+++ b/tests/test_sensors.cpp
@@ -5,6 +5,7 @@
 #include <multigauge/value/ValueRegistry.h>
 
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -45,6 +46,9 @@ public:
 
 class FakeProvider final : public mg::sensor::Provider {
 public:
+    explicit FakeProvider(int* destructionCount = nullptr) : destructionCount(destructionCount) {}
+    ~FakeProvider() override { if (destructionCount) ++*destructionCount; }
+
     std::string_view id() const noexcept override { return "aux-main"; }
     std::string_view name() const noexcept override { return "Auxiliary"; }
     std::string_view type() const noexcept override { return "aux"; }
@@ -64,6 +68,7 @@ public:
     FakeSensor sensor;
     int updates = 0;
     int loadedMode = 0;
+    int* destructionCount = nullptr;
 };
 
 TEST_CASE("sensor registry borrows providers and maintains its index") {
@@ -97,28 +102,29 @@ TEST_CASE("sensor manager persists provider configuration and resolves bindings"
     mg::sensor::Manager manager(fs, "/telemetry");
     REQUIRE(manager.load());
 
-    FakeProvider provider;
-    REQUIRE(manager.registerProvider(provider));
+    auto provider = std::make_unique<FakeProvider>();
+    FakeProvider* providerView = provider.get();
+    REQUIRE(manager.registerProvider(std::move(provider)));
     CHECK_FALSE(manager.load());
     const auto config = mg::json::parse(R"({"mode":7})");
     REQUIRE(config.valid());
     REQUIRE(manager.configureProvider("aux-main", config.root()).ok);
-    CHECK(provider.loadedMode == 7);
+    CHECK(providerView->loadedMode == 7);
     const auto invalidConfig = mg::json::parse(R"({"mode":-1})");
     REQUIRE(invalidConfig.valid());
     CHECK_FALSE(manager.configureProvider("aux-main", invalidConfig.root()).ok);
-    CHECK(manager.findProvider("aux-main") == &provider);
-    CHECK(provider.loadedMode == 7);
+    CHECK(manager.findProvider("aux-main") == providerView);
+    CHECK(providerView->loadedMode == 7);
 
     REQUIRE(manager.defineUserValue({"customRPM", "Custom RPM", "revolutions", 0.0F, 10000.0F}).ok);
     REQUIRE(manager.upsertBinding({"aux-rpm", "aux-main", "rpm", "customRPM", true, 10, std::chrono::milliseconds(100)}).ok);
     CHECK_FALSE(manager.removeUserValue("customRPM"));
 
     manager.update(std::chrono::milliseconds(16), std::chrono::microseconds{});
-    CHECK(provider.updates == 1);
+    CHECK(providerView->updates == 1);
     CHECK(mg::ValueRegistry::value(mg::ValueRegistry::resolve("customRPM")) == doctest::Approx(4000.0F));
 
-    provider.sensor.reading_.status = mg::sensor::Status::Unavailable;
+    providerView->sensor.reading_.status = mg::sensor::Status::Unavailable;
     manager.update(std::chrono::milliseconds(16), std::chrono::milliseconds(101));
     CHECK_FALSE(mg::ValueRegistry::available(mg::ValueRegistry::resolve("customRPM")));
     REQUIRE(manager.save());
@@ -129,9 +135,22 @@ TEST_CASE("sensor manager persists provider configuration and resolves bindings"
     std::vector<mg::sensor::UserValueConfig> values;
     REQUIRE(restoredManager.listUserValues(values));
     CHECK(values.size() == 1);
-    FakeProvider restored;
-    REQUIRE(restoredManager.registerProvider(restored));
-    CHECK(restored.loadedMode == 7);
+    auto restored = std::make_unique<FakeProvider>();
+    FakeProvider* restoredView = restored.get();
+    REQUIRE(restoredManager.registerProvider(std::move(restored)));
+    CHECK(restoredView->loadedMode == 7);
+}
+
+TEST_CASE("sensor manager owns registered provider lifetimes") {
+    MemoryFileSystem fs;
+    mg::sensor::Manager manager(fs, "/telemetry");
+    REQUIRE(manager.load());
+
+    int destructionCount = 0;
+    REQUIRE(manager.registerProvider(std::make_unique<FakeProvider>(&destructionCount)));
+    REQUIRE(manager.unregisterProvider("aux-main"));
+    CHECK(destructionCount == 1);
+    CHECK(manager.findProvider("aux-main") == nullptr);
 }
 
 TEST_CASE("sensor manager rejects malformed state without replacing current state") {


### PR DESCRIPTION
##  What changed?

`mg::sensor::Manager` now owns registered sensor providers through `std::unique_ptr` rather than borrowing host-owned instances.

## Why?

Provider configuration, registration, updates, bindings, and removal are already managed by Manager. Owning providers there makes their lifetime explicit and prevents ports from needing to maintain fragile provider/manager destruction ordering.

## Implementation notes

`Registry` remains a fixed-capacity borrowed index for fast lookup and update dispatch. Manager unregisters a provider from the registry before destroying it, while retaining persisted configuration for later re-registration.
Updated the ESP32 AUX integration to transfer its `AuxProvider` into the manager.

## Testing

Added core coverage confirming that unregistering a provider destroys the manager-owned instance and removes it from lookup.

`git diff --check` passed. A focused native core test build was started but stopped during cold third-party dependency downloads; no completed build or hardware test was run.

## Checklist

- [X] This PR is limited to one logical feature or change
- [X] Public APIs, configuration, or documentation were updated if needed.
- [X] No debugging code, temporary files, or unrelated changes are included