### PR TITLE
Add Top Level Header File

### DIFF
--- a/include/multigauge/Multigauge.h
+++ b/include/multigauge/Multigauge.h
@@ -1,0 +1,11 @@
+#pragma once
+
+/// @file Multigauge.h
+/// @brief Port-facing Multigauge runtime and platform-service API.
+
+#include <multigauge/Runtime.h>
+#include <multigauge/graphics/GraphicsContext.h>
+#include <multigauge/io/FileSystem.h>
+#include <multigauge/io/Logger.h>
+#include <multigauge/io/Time.h>
+

--- a/tests/test_properties.cpp
+++ b/tests/test_properties.cpp
@@ -1,5 +1,6 @@
 #include <doctest/doctest.h>
 
+#include <multigauge/Multigauge.h>
 #include <multigauge/properties/PropertyCodec.h>
 #include <multigauge/properties/PropertyObject.h>
 


### PR DESCRIPTION
##  What changed?

Added a top level header file to let ports import a single file instead of multiple.

## Why?

Ports imported a mess of specific files, this gives all ports just what they need in a single file.

## Implementation notes

`multigauge/Multigauge.h` is the entry point. 

## Checklist

- [X] This PR is limited to one logical feature or change
- [X] Public APIs, configuration, or documentation were updated if needed.
- [X] No debugging code, temporary files, or unrelated changes are included