### PR TITLE
Expand Inspector To Other PropertyObjects

### DIFF
--- a/include/multigauge/gauge/Element.h
+++ b/include/multigauge/gauge/Element.h
@@ -81,7 +81,8 @@ public:
             MG_CONTROL_IF("axis-pair", MG_IN("floating.mode", "relative", "absolute"),
                           {MG_BIND("value", "floating.offset")});
             MG_PROPERTY_IF("floating.zIndex", "Z Index", "number", MG_IN("floating.mode", "relative", "absolute"));
-            MG_PROPERTY_IF("floating.expand", "Expand", "json", MG_IN("floating.mode", "relative", "absolute"));
+            MG_CONTROL_IF("axis-pair", MG_IN("floating.mode", "relative", "absolute"),
+                          {MG_BIND("value", "floating.expand")});
         });
         MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/gauge/GaugeFace.h
+++ b/include/multigauge/gauge/GaugeFace.h
@@ -315,7 +315,7 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Background", {
-        MG_PROPERTY("bgColor", "Background Color", "json");
+        MG_PROPERTY("bgColor", "Background Color", "color");
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/FrameElement.h
+++ b/include/multigauge/gauge/elements/FrameElement.h
@@ -31,6 +31,15 @@ private:
     MG_PROPS_BEGIN()
         MG_PROP(fill_, "fill")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Appearance", {
+        MG_PROPERTY("fill", "Fill", "color");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/Graph.h
+++ b/include/multigauge/gauge/elements/Graph.h
@@ -58,5 +58,21 @@ private:
     MG_PROP(borderColor_, "borderColor")
     MG_PROP(value_, "value")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Graph", {
+        MG_PROPERTY("seconds", "Window (seconds)", "number");
+        MG_PROPERTY("value", "Value", "value-ref");
+    });
+    MG_SECTION("Colors", {
+        MG_PROPERTY("bgColor", "Background", "color");
+        MG_PROPERTY("secondsColor", "Time Labels", "color");
+        MG_PROPERTY("graphColor", "Graph", "color");
+        MG_PROPERTY("borderColor", "Border", "color");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/Horizon.h
+++ b/include/multigauge/gauge/elements/Horizon.h
@@ -33,5 +33,17 @@ private:
     MG_PROP(horizonColor_, "horizonColor")
     MG_PROP(borderColor_, "borderColor")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Colors", {
+        MG_PROPERTY("bgColor", "Background", "color");
+        MG_PROPERTY("groundColor", "Ground", "color");
+        MG_PROPERTY("horizonColor", "Horizon", "color");
+        MG_PROPERTY("borderColor", "Border", "color");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/circular/CircularElement.h
+++ b/include/multigauge/gauge/elements/circular/CircularElement.h
@@ -38,6 +38,19 @@ private:
     MG_PROP(startAngle_, "startAngle")
     MG_PROP(endAngle_, "endAngle")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Circular", {
+        MG_PROPERTY("value", "Value", "value-ref");
+        MG_ROW({
+            MG_PROPERTY("startAngle", "Start Angle", "number");
+            MG_PROPERTY("endAngle", "End Angle", "number");
+        });
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/circular/CircularNeedle.h
+++ b/include/multigauge/gauge/elements/circular/CircularNeedle.h
@@ -26,6 +26,25 @@ private:
     MG_PROP(paint_, "paint")
     MG_PROP(radius_, "radius")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Circular", {
+        MG_PROPERTY("value", "Value", "value-ref");
+        MG_ROW({
+            MG_PROPERTY("startAngle", "Start Angle", "number");
+            MG_PROPERTY("endAngle", "End Angle", "number");
+        });
+    });
+    MG_SECTION("Needle", {
+        MG_PROPERTY("paint.fill", "Fill", "color");
+        MG_PROPERTY("paint.stroke", "Stroke", "color");
+        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
+        MG_PROPERTY("radius", "Radius", "number");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/circular/CircularScale.h
+++ b/include/multigauge/gauge/elements/circular/CircularScale.h
@@ -29,6 +29,21 @@ private:
     MG_PROP(ticks_, "ticks")
     MG_PROP(radius_, "radius")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Circular", {
+        MG_PROPERTY("value", "Value", "value-ref");
+        MG_ROW({
+            MG_PROPERTY("startAngle", "Start Angle", "number");
+            MG_PROPERTY("endAngle", "End Angle", "number");
+        });
+        MG_PROPERTY("radius", "Radius", "number");
+    });
+    MG_INCLUDE("ticks");
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/primitives/CircleElement.h
+++ b/include/multigauge/gauge/elements/primitives/CircleElement.h
@@ -24,6 +24,17 @@ private:
     MG_PROPS_BEGIN()
     MG_PROP(paint_, "paint")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Appearance", {
+        MG_PROPERTY("paint.fill", "Fill", "color");
+        MG_PROPERTY("paint.stroke", "Stroke", "color");
+        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/primitives/ImageElement.h
+++ b/include/multigauge/gauge/elements/primitives/ImageElement.h
@@ -38,6 +38,16 @@ private:
     MG_PROP(imagePath_, "path")
     MG_PROP(fit_, "fit")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Image", {
+        MG_PROPERTY("path", "Asset Path", "text");
+        MG_PROPERTY("fit", "Fit", "select");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/primitives/RectangleElement.h
+++ b/include/multigauge/gauge/elements/primitives/RectangleElement.h
@@ -26,6 +26,18 @@ private:
     MG_PROP(paint_, "paint")
     MG_PROP(radius_, "radius")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Appearance", {
+        MG_PROPERTY("paint.fill", "Fill", "color");
+        MG_PROPERTY("paint.stroke", "Stroke", "color");
+        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
+        MG_PROPERTY("radius", "Corner Radius", "number");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/elements/primitives/TextElement.h
+++ b/include/multigauge/gauge/elements/primitives/TextElement.h
@@ -33,6 +33,22 @@ private:
     MG_PROP(useEllipses_, "ellipses")
     MG_PROP(useHyphens_, "hyphens")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Text", {
+        MG_PROPERTY("text", "Content", "text");
+        MG_PROPERTY("paint.family", "Font", "text");
+        MG_PROPERTY("paint.pt", "Size", "number");
+        MG_PROPERTY("paint.color", "Color", "color");
+    });
+    MG_SECTION("Wrapping", {
+        MG_PROPERTY("ellipses", "Ellipses", "boolean");
+        MG_PROPERTY("hyphens", "Hyphens", "boolean");
+    });
+    MG_INCLUDE("layout");
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::gauge

--- a/include/multigauge/gauge/ticks/RootTick.h
+++ b/include/multigauge/gauge/ticks/RootTick.h
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <multigauge/gauge/ticks/TickStyle.h>
+#include <multigauge/properties/meta/Inspector.h>
 #include <multigauge/utils/Math.h>
 #include <optional>
 #include <vector>
@@ -56,5 +57,24 @@ struct RootTick : public ::mg::PropertyObject {
     MG_PROP(thickness, "thickness")
     MG_PROP(paint, "paint")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Spacing", {
+        MG_PROPERTY("useDivisions", "Use Divisions", "boolean");
+        MG_PROPERTY_IF("divisions", "Divisions", "number", MG_IN("useDivisions", "true"));
+        MG_PROPERTY_IF("interval", "Interval", "number", MG_IN("useDivisions", "false"));
+    });
+    MG_SECTION("Appearance", {
+        MG_PROPERTY("length", "Length", "number");
+        MG_PROPERTY("thickness", "Thickness", "number");
+        MG_PROPERTY("paint.fill", "Fill Gradient", "gradient");
+        MG_PROPERTY("paint.stroke", "Stroke Gradient", "gradient");
+        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
+    });
+    MG_INSPECTOR_END()
+#endif
+
+public:
 };
 } // namespace mg::gauge

--- a/include/multigauge/gauge/ticks/SubTick.h
+++ b/include/multigauge/gauge/ticks/SubTick.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <multigauge/gauge/ticks/TickStyle.h>
+#include <multigauge/properties/meta/Inspector.h>
 #include <optional>
 #include <vector>
 
@@ -35,5 +36,17 @@ struct SubTick : public ::mg::PropertyObject {
     MG_PROP(thickness, "thickness")
     MG_PROP(paint, "paint")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Subticks", {
+        MG_PROPERTY("divisions", "Divisions", "number");
+        MG_PROPERTY("length", "Length", "number");
+        MG_PROPERTY("thickness", "Thickness", "number");
+    });
+    MG_INSPECTOR_END()
+#endif
+
+public:
 };
 } // namespace mg::gauge

--- a/include/multigauge/gauge/ticks/TickList.h
+++ b/include/multigauge/gauge/ticks/TickList.h
@@ -140,7 +140,19 @@ public:
     MG_PROPS_BEGIN()
         MG_PROP(root, "root")
         MG_PROP(subs, "subs")
-        MG_PROP(offset, "offset")
+    MG_PROP(offset, "offset")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_INCLUDE("root");
+    MG_SECTION("Subticks", {
+        MG_PROPERTY("subs", "Levels", "tick-levels");
+        MG_PROPERTY("offset", "Offset", "number");
+    });
+    MG_INSPECTOR_END()
+#endif
+
+public:
 };
 } // namespace mg::gauge

--- a/include/multigauge/graphics/TextPaint.h
+++ b/include/multigauge/graphics/TextPaint.h
@@ -2,6 +2,7 @@
 
 #include <multigauge/graphics/font/Font.h>
 #include <multigauge/graphics/colors/Color.h>
+#include <multigauge/properties/meta/Inspector.h>
 
 
 #include <stdint.h>
@@ -25,6 +26,17 @@ struct TextPaint : public ::mg::PropertyObject {
     MG_PROP(color, "color")
     MG_PROPS_END()
 
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Typography", {
+        MG_PROPERTY("family", "Font", "text");
+        MG_PROPERTY("pt", "Size", "number");
+        MG_PROPERTY("color", "Color", "color");
+    });
+    MG_INSPECTOR_END()
+#endif
+
+public:
     TextPaint() = default;
 };
 

--- a/include/multigauge/graphics/colors/Color.h
+++ b/include/multigauge/graphics/colors/Color.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <multigauge/properties/meta/Inspector.h>
+
 #include <cstdint>
 #include <memory>
 
@@ -54,6 +56,17 @@ struct Paint : public ::mg::PropertyObject {
     MG_PROP(thickness, "thickness")
     MG_PROPS_END()
 
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Paint", {
+        MG_PROPERTY("fill", "Fill", "color");
+        MG_PROPERTY("stroke", "Stroke", "color");
+        MG_PROPERTY("thickness", "Stroke Width", "number");
+    });
+    MG_INSPECTOR_END()
+#endif
+
+public:
     Paint();
     Paint(OwnedColor fill, OwnedColor stroke, float thickness = 1.0f);
 };

--- a/include/multigauge/graphics/colors/ColorTimeline.h
+++ b/include/multigauge/graphics/colors/ColorTimeline.h
@@ -18,6 +18,16 @@ struct ColorKeyframe : public ::mg::PropertyObject {
     MG_PROP(color, "color")
     MG_PROPS_END()
 
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Gradient Stop", {
+        MG_PROPERTY("pos", "Position", "number");
+        MG_PROPERTY("color", "Color", "color");
+    });
+    MG_INSPECTOR_END()
+#endif
+
+public:
     ColorKeyframe() = default;
     ColorKeyframe(OwnedColor color, float position);
     ColorKeyframe(const ColorKeyframe& other);
@@ -36,6 +46,14 @@ class ColorTimeline : public ::mg::PropertyObject {
     MG_PROPS_BEGIN()
     MG_PROP(keyframes, "keyframes")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Gradient", {
+        MG_PROPERTY("keyframes", "Stops", "gradient");
+    });
+    MG_INSPECTOR_END()
+#endif
 
 public:
     ColorTimeline() = default;
@@ -81,6 +99,17 @@ struct PaintTimeline : public ::mg::PropertyObject {
     MG_PROP(thickness, "thickness")
     MG_PROPS_END()
 
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Paint", {
+        MG_PROPERTY("fill", "Fill Gradient", "gradient");
+        MG_PROPERTY("stroke", "Stroke Gradient", "gradient");
+        MG_PROPERTY("thickness", "Stroke Width", "number");
+    });
+    MG_INSPECTOR_END()
+#endif
+
+public:
     PaintTimeline() = default;
     PaintTimeline(ColorTimeline fill, ColorTimeline stroke, float thickness);
     [[nodiscard]] ResolvedPaint sample(float normalizedPosition, const ColorResolver::Frame& frame) const noexcept;

--- a/include/multigauge/graphics/colors/StaticColor.h
+++ b/include/multigauge/graphics/colors/StaticColor.h
@@ -14,6 +14,14 @@ class StaticColor final : public Color {
     MG_PROP(color, "color")
     MG_PROPS_END()
 
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Color", {
+        MG_PROPERTY("color", "Color", "color");
+    });
+    MG_INSPECTOR_END()
+#endif
+
 public:
     StaticColor();
     explicit StaticColor(rgba color);

--- a/include/multigauge/graphics/colors/TimeColor.h
+++ b/include/multigauge/graphics/colors/TimeColor.h
@@ -31,6 +31,18 @@ private:
     MG_PROP(loopType, "loop")
     MG_PROP(periodMs, "periodMs")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Animation", {
+        MG_PROPERTY("loop", "Loop", "select");
+        MG_PROPERTY("periodMs", "Period (ms)", "number");
+    });
+    MG_SECTION("Gradient", {
+        MG_PROPERTY("timeline", "Stops", "gradient");
+    });
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::graphics

--- a/include/multigauge/graphics/colors/UserColor.h
+++ b/include/multigauge/graphics/colors/UserColor.h
@@ -23,6 +23,14 @@ private:
     MG_PROPS_BEGIN()
     MG_PROP(slot, "slot")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Color", {
+        MG_PROPERTY("slot", "Palette Slot", "select");
+    });
+    MG_INSPECTOR_END()
+#endif
 };
 
 } // namespace mg::graphics

--- a/include/multigauge/graphics/colors/ValueColor.h
+++ b/include/multigauge/graphics/colors/ValueColor.h
@@ -18,6 +18,15 @@ class ValueColor final : public Color {
     MG_PROP(value, "id")
     MG_PROPS_END()
 
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Value Color", {
+        MG_PROPERTY("id", "Value ID", "text");
+        MG_PROPERTY("timeline", "Stops", "gradient");
+    });
+    MG_INSPECTOR_END()
+#endif
+
 public:
     ValueColor() = default;
     ValueColor(::mg::ValueRef value, ColorTimeline timeline);

--- a/include/multigauge/value/ValueView.h
+++ b/include/multigauge/value/ValueView.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <multigauge/properties/PropertyObject.h>
+#include <multigauge/properties/meta/Inspector.h>
 #include <multigauge/value/ValueRef.h>
 
 #include <optional>
@@ -71,8 +72,21 @@ private:
         MG_PROP(value_, "id")
         MG_PROP(minimumBase_, "min")
         MG_PROP(maximumBase_, "max")
-        MG_PROP(unitIndex_, "unitIndex")
+    MG_PROP(unitIndex_, "unitIndex")
     MG_PROPS_END()
+
+#if MG_BUILD_EDITOR
+    MG_INSPECTOR_BEGIN()
+    MG_SECTION("Value", {
+        MG_PROPERTY("id", "ID", "text");
+        MG_ROW({
+            MG_PROPERTY("min", "Minimum", "number");
+            MG_PROPERTY("max", "Maximum", "number");
+        });
+        MG_PROPERTY("unitIndex", "Unit Index", "number");
+    });
+    MG_INSPECTOR_END()
+#endif
 };
 
 CODEC_BEGIN(ValueView)

--- a/src/gauge/GaugeFace.cpp
+++ b/src/gauge/GaugeFace.cpp
@@ -547,7 +547,8 @@ bool GaugeFace::saveChildren(json::Writer& writer, NodeHandle parent) const {
 }
 
 void GaugeFace::draw(::mg::graphics::Graphics& graphics) {
-    graphics.fillAll(backgroundColor_.get());
+    if (backgroundColor_) graphics.fillAll(backgroundColor_.get());
+    else graphics.fillAll(::mg::graphics::rgba(0, 0, 0, 0));
 
     for (NodeHandle root = firstRoot_; root.valid();) {
         Node* rootNode = node(root);

--- a/tests/test_gauge.cpp
+++ b/tests/test_gauge.cpp
@@ -4,8 +4,26 @@
 #include <multigauge/editor/Editor.h>
 #include <multigauge/gauge/GaugeFace.h>
 #include <multigauge/gauge/elements/CustomElement.h>
+#include <multigauge/gauge/elements/FrameElement.h>
 #include <multigauge/gauge/elements/Graph.h>
+#include <multigauge/gauge/elements/Horizon.h>
+#include <multigauge/gauge/elements/circular/CircularNeedle.h>
+#include <multigauge/gauge/elements/circular/CircularScale.h>
+#include <multigauge/gauge/elements/primitives/CircleElement.h>
+#include <multigauge/gauge/elements/primitives/ImageElement.h>
+#include <multigauge/gauge/elements/primitives/RectangleElement.h>
+#include <multigauge/gauge/elements/primitives/TextElement.h>
+#include <multigauge/gauge/ticks/RootTick.h>
+#include <multigauge/gauge/ticks/SubTick.h>
+#include <multigauge/gauge/ticks/TickList.h>
 #include <multigauge/graphics/Graphics.h>
+#include <multigauge/graphics/TextPaint.h>
+#include <multigauge/graphics/colors/ColorTimeline.h>
+#include <multigauge/graphics/colors/StaticColor.h>
+#include <multigauge/graphics/colors/TimeColor.h>
+#include <multigauge/graphics/colors/UserColor.h>
+#include <multigauge/graphics/colors/ValueColor.h>
+#include <multigauge/value/ValueView.h>
 
 #include <string>
 #include <string_view>
@@ -115,8 +133,9 @@ public:
     };
 
     std::vector<RoundedRect> roundedRects;
+    std::vector<mg::graphics::rgba> clears;
 
-    void clear(mg::graphics::rgba) override {}
+    void clear(mg::graphics::rgba color) override { clears.push_back(color); }
     void pixel(int, int, mg::graphics::rgba) override {}
     void line(int, int, int, int, mg::graphics::rgba, float) override {}
     void rect(int, int, int, int, mg::graphics::rgba) override {}
@@ -149,6 +168,74 @@ public:
     void clip(int, int, int, int) override {}
     void clearClip() override {}
 };
+
+TEST_CASE("a face without a background clears transparently") {
+    mg::gauge::GaugeFace face;
+    RecordingGraphicsContext context;
+    REQUIRE(context.resize(250, 240));
+    mg::graphics::Graphics graphics(context);
+
+    graphics.setFill(mg::graphics::rgba(234, 53, 31));
+    face.draw(graphics);
+
+    REQUIRE(context.clears.size() == 1);
+    CHECK(context.clears[0].r == 0);
+    CHECK(context.clears[0].g == 0);
+    CHECK(context.clears[0].b == 0);
+    CHECK(context.clears[0].a == 0);
+}
+
+TEST_CASE("built-in elements provide inspector layouts") {
+    const auto checkLayout = [](mg::PropertyObject& object) {
+        auto document = mg::json::object();
+        auto writer = document.writer();
+        REQUIRE(object.writeInspectorMeta(writer));
+        CHECK(document.root().member("layout").isArray());
+    };
+
+    mg::gauge::FrameElement frame;
+    mg::gauge::Graph graph;
+    mg::gauge::Horizon horizon;
+    mg::gauge::CircleElement circle;
+    mg::gauge::ImageElement image;
+    mg::gauge::RectangleElement rectangle;
+    mg::gauge::TextElement text;
+    mg::gauge::CircularNeedle needle;
+    mg::gauge::CircularScale scale;
+    mg::graphics::Paint paint;
+    mg::graphics::TextPaint textPaint;
+    mg::graphics::StaticColor staticColor;
+    mg::graphics::TimeColor timeColor;
+    mg::graphics::UserColor userColor;
+    mg::graphics::ValueColor valueColor;
+    mg::graphics::ColorTimeline timeline;
+    mg::graphics::PaintTimeline paintTimeline;
+    mg::ValueView valueView;
+    mg::gauge::RootTick rootTick;
+    mg::gauge::SubTick subTick;
+    mg::gauge::TickList tickList;
+    checkLayout(frame);
+    checkLayout(graph);
+    checkLayout(horizon);
+    checkLayout(circle);
+    checkLayout(image);
+    checkLayout(rectangle);
+    checkLayout(text);
+    checkLayout(needle);
+    checkLayout(scale);
+    checkLayout(paint);
+    checkLayout(textPaint);
+    checkLayout(staticColor);
+    checkLayout(timeColor);
+    checkLayout(userColor);
+    checkLayout(valueColor);
+    checkLayout(timeline);
+    checkLayout(paintTimeline);
+    checkLayout(valueView);
+    checkLayout(rootTick);
+    checkLayout(subTick);
+    checkLayout(tickList);
+}
 
 TEST_CASE("Clay layout properties serialize grouped padding and floating placement") {
     const auto source = mg::json::parse(R"({
@@ -229,16 +316,58 @@ TEST_CASE("layout emits an authoritative structured inspector") {
     CHECK(widget == "number");
 }
 
+TEST_CASE("layout inspector emits enum options and accepts nested property updates") {
+    mg::gauge::Element element{"test"};
+    auto document = mg::json::object();
+    auto writer = document.writer();
+    REQUIRE(element.writeInspectorMeta(writer));
+
+    const auto layout = document.root().member("properties").element(0);
+    const auto width = layout.member("properties").element(0);
+    const auto sizeMode = width.member("properties").element(0);
+    REQUIRE(sizeMode.member("options").isArray());
+    CHECK(sizeMode.member("options").size() == 4);
+
+    const auto floating = layout.member("properties").element(6);
+    const auto mode = floating.member("properties").element(0);
+    REQUIRE(mode.member("options").isArray());
+    CHECK(mode.member("options").size() == 3);
+
+    mg::PropertyObject* owner = nullptr;
+    const mg::Property* property = nullptr;
+    REQUIRE(element.resolvePath("layout.floating.mode", owner, property));
+    const auto value = mg::json::parse(R"("relative")");
+    REQUIRE(owner->setProperty(property->key, value.root()));
+
+    REQUIRE(element.resolvePath("layout.width.mode", owner, property));
+    const auto fixed = mg::json::parse(R"("fixed")");
+    REQUIRE(owner->setProperty(property->key, fixed.root()));
+}
+
 TEST_CASE("face inspector includes layout sections without a wrapper section") {
     mg::gauge::GaugeFace face;
+    mg::PropertyObject* owner = nullptr;
+    const mg::Property* property = nullptr;
+    REQUIRE(face.resolvePath("bgColor", owner, property));
+    const auto color = mg::json::parse(R"("#336699")");
+    REQUIRE(owner->setProperty(property->key, color.root()));
+
     auto document = mg::json::object();
     auto writer = document.writer();
     REQUIRE(face.writeInspectorMeta(writer));
 
     const auto inspector = document.root();
+    std::string_view backgroundValue;
+    REQUIRE(inspector.member("properties").element(1).member("properties").element(0).member("value").read(backgroundValue));
+    CHECK(backgroundValue == "#336699FF");
     const auto presentation = inspector.member("layout");
     REQUIRE(presentation.isArray());
     REQUIRE(presentation.size() == 2);
+
+    const auto background = presentation.element(0).member("children").element(0);
+    std::string_view widget;
+    REQUIRE(background.member("widget").read(widget));
+    CHECK(widget == "color");
 
     std::string_view type;
     std::string_view path;


### PR DESCRIPTION
##  What changed?

Added inspector metadata to all other `PropertyObject`s.

## Why?

So they can be tested in the editor. This does not represent a complete finished version of what widgets will be used and the inspector layout.

## Checklist

- [X] This PR is limited to one logical feature or change
- [X] Public APIs, configuration, or documentation were updated if needed.
- [X] No debugging code, temporary files, or unrelated changes are included