### PR TITLE
Feat/polymorphic collection

### DIFF
--- a/include/multigauge/gauge/Element.h
+++ b/include/multigauge/gauge/Element.h
@@ -60,28 +60,28 @@ public:
         MG_INSPECTOR_BEGIN()
         MG_SECTION("Size", {
             MG_LABELED_ROW("Dimensions", {
-                MG_PROPERTY("width", "Width", "layout-size");
-                MG_PROPERTY("height", "Height", "layout-size");
+                MG_PROPERTY("width", "Width", widget::layoutSize);
+                MG_PROPERTY("height", "Height", widget::layoutSize);
             });
-            MG_PROPERTY("aspectRatio", "Aspect Ratio", "number");
+            MG_PROPERTY("aspectRatio", "Aspect Ratio", widget::number);
         });
         MG_SECTION("Layout", {
-            MG_CONTROL("direction-toggle", {MG_BIND("value", "direction")});
+            MG_CONTROL(widget::directionToggle, {MG_BIND("value", "direction")});
             MG_ROW({
-                MG_CONTROL("alignment-grid", {MG_BIND("value", "childAlignment")});
-                MG_PROPERTY("childGap", "Child Gap", "number");
+                MG_CONTROL(widget::alignmentGrid, {MG_BIND("value", "childAlignment")});
+                MG_PROPERTY("childGap", "Child Gap", widget::number);
             });
-            MG_CONTROL("insets", {MG_BIND("value", "padding")});
+            MG_CONTROL(widget::insets, {MG_BIND("value", "padding")});
         });
         MG_SECTION("Position", {
-            MG_PROPERTY("floating.mode", "Mode", "select");
-            MG_CONTROL_IF("anchor-pair", MG_IN("floating.mode", "relative", "absolute"),
+            MG_PROPERTY("floating.mode", "Mode", widget::select);
+            MG_CONTROL_IF(widget::anchorPair, MG_IN("floating.mode", "relative", "absolute"),
                           {MG_BIND("target", "floating.parentAnchor"),
                            MG_BIND("element", "floating.elementAnchor")});
-            MG_CONTROL_IF("axis-pair", MG_IN("floating.mode", "relative", "absolute"),
+            MG_CONTROL_IF(widget::axisPair, MG_IN("floating.mode", "relative", "absolute"),
                           {MG_BIND("value", "floating.offset")});
-            MG_PROPERTY_IF("floating.zIndex", "Z Index", "number", MG_IN("floating.mode", "relative", "absolute"));
-            MG_CONTROL_IF("axis-pair", MG_IN("floating.mode", "relative", "absolute"),
+            MG_PROPERTY_IF("floating.zIndex", "Z Index", widget::number, MG_IN("floating.mode", "relative", "absolute"));
+            MG_CONTROL_IF(widget::axisPair, MG_IN("floating.mode", "relative", "absolute"),
                           {MG_BIND("value", "floating.expand")});
         });
         MG_INSPECTOR_END()

--- a/include/multigauge/gauge/GaugeFace.h
+++ b/include/multigauge/gauge/GaugeFace.h
@@ -47,12 +47,12 @@ public:
 #if MG_BUILD_EDITOR
         MG_INSPECTOR_BEGIN()
         MG_SECTION("Layout", {
-            MG_CONTROL("direction-toggle", {MG_BIND("value", "direction")});
+            MG_CONTROL(widget::directionToggle, {MG_BIND("value", "direction")});
             MG_ROW({
-                MG_CONTROL("alignment-grid", {MG_BIND("value", "childAlignment")});
-                MG_PROPERTY("childGap", "Child Gap", "number");
+                MG_CONTROL(widget::alignmentGrid, {MG_BIND("value", "childAlignment")});
+                MG_PROPERTY("childGap", "Child Gap", widget::number);
             });
-            MG_CONTROL("insets", {MG_BIND("value", "padding")});
+            MG_CONTROL(widget::insets, {MG_BIND("value", "padding")});
         });
         MG_INSPECTOR_END()
 #endif
@@ -312,7 +312,7 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Background", {
-        MG_PROPERTY("bgColor", "Background Color", "color");
+        MG_PROPERTY("bgColor", "Background Color", widget::color);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/FrameElement.h
+++ b/include/multigauge/gauge/elements/FrameElement.h
@@ -35,7 +35,7 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Appearance", {
-        MG_PROPERTY("fill", "Fill", "color");
+        MG_PROPERTY("fill", "Fill", widget::color);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/Graph.h
+++ b/include/multigauge/gauge/elements/Graph.h
@@ -62,14 +62,14 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Graph", {
-        MG_PROPERTY("seconds", "Window (seconds)", "number");
-        MG_PROPERTY("value", "Value", "value-ref");
+        MG_PROPERTY("seconds", "Window (seconds)", widget::number);
+        MG_PROPERTY("value", "Value", widget::valueRef);
     });
     MG_SECTION("Colors", {
-        MG_PROPERTY("bgColor", "Background", "color");
-        MG_PROPERTY("secondsColor", "Time Labels", "color");
-        MG_PROPERTY("graphColor", "Graph", "color");
-        MG_PROPERTY("borderColor", "Border", "color");
+        MG_PROPERTY("bgColor", "Background", widget::color);
+        MG_PROPERTY("secondsColor", "Time Labels", widget::color);
+        MG_PROPERTY("graphColor", "Graph", widget::color);
+        MG_PROPERTY("borderColor", "Border", widget::color);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/Horizon.h
+++ b/include/multigauge/gauge/elements/Horizon.h
@@ -37,10 +37,10 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Colors", {
-        MG_PROPERTY("bgColor", "Background", "color");
-        MG_PROPERTY("groundColor", "Ground", "color");
-        MG_PROPERTY("horizonColor", "Horizon", "color");
-        MG_PROPERTY("borderColor", "Border", "color");
+        MG_PROPERTY("bgColor", "Background", widget::color);
+        MG_PROPERTY("groundColor", "Ground", widget::color);
+        MG_PROPERTY("horizonColor", "Horizon", widget::color);
+        MG_PROPERTY("borderColor", "Border", widget::color);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/Radial.h
+++ b/include/multigauge/gauge/elements/Radial.h
@@ -42,10 +42,10 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Needle", {
-        MG_PROPERTY("paint.fill", "Fill", "color");
-        MG_PROPERTY("paint.stroke", "Stroke", "color");
-        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
-        MG_PROPERTY("radius", "Radius", "number");
+        MG_PROPERTY("paint.fill", "Fill", widget::color);
+        MG_PROPERTY("paint.stroke", "Stroke", widget::color);
+        MG_PROPERTY("paint.thickness", "Stroke Width", widget::number);
+        MG_PROPERTY("radius", "Radius", widget::number);
     });
     MG_INSPECTOR_END()
 #endif
@@ -68,7 +68,7 @@ private:
     MG_PROPS_END()
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
-    MG_SECTION("Scale", { MG_PROPERTY("radius", "Radius", "number"); });
+    MG_SECTION("Scale", { MG_PROPERTY("radius", "Radius", widget::number); });
     MG_INCLUDE("ticks");
     MG_INSPECTOR_END()
 #endif
@@ -97,10 +97,10 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Radial", {
-        MG_PROPERTY("value", "Value", "value-ref");
-        MG_ROW({ MG_PROPERTY("startAngle", "Start Angle", "number"); MG_PROPERTY("endAngle", "End Angle", "number"); });
+        MG_PROPERTY("value", "Value", widget::valueRef);
+        MG_ROW({ MG_PROPERTY("startAngle", "Start Angle", widget::number); MG_PROPERTY("endAngle", "End Angle", widget::number); });
     });
-    MG_SECTION("Parts", { MG_PROPERTY("parts", "Parts", "radial-parts"); });
+    MG_SECTION("Parts", { MG_PROPERTY("parts", "Parts", widget::collection); });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/gauge/elements/primitives/CircleElement.h
+++ b/include/multigauge/gauge/elements/primitives/CircleElement.h
@@ -28,9 +28,9 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Appearance", {
-        MG_PROPERTY("paint.fill", "Fill", "color");
-        MG_PROPERTY("paint.stroke", "Stroke", "color");
-        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
+        MG_PROPERTY("paint.fill", "Fill", widget::color);
+        MG_PROPERTY("paint.stroke", "Stroke", widget::color);
+        MG_PROPERTY("paint.thickness", "Stroke Width", widget::number);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/primitives/ImageElement.h
+++ b/include/multigauge/gauge/elements/primitives/ImageElement.h
@@ -42,8 +42,8 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Image", {
-        MG_PROPERTY("path", "Asset Path", "text");
-        MG_PROPERTY("fit", "Fit", "select");
+        MG_PROPERTY("path", "Asset Path", widget::text);
+        MG_PROPERTY("fit", "Fit", widget::select);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/primitives/RectangleElement.h
+++ b/include/multigauge/gauge/elements/primitives/RectangleElement.h
@@ -30,10 +30,10 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Appearance", {
-        MG_PROPERTY("paint.fill", "Fill", "color");
-        MG_PROPERTY("paint.stroke", "Stroke", "color");
-        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
-        MG_PROPERTY("radius", "Corner Radius", "number");
+        MG_PROPERTY("paint.fill", "Fill", widget::color);
+        MG_PROPERTY("paint.stroke", "Stroke", widget::color);
+        MG_PROPERTY("paint.thickness", "Stroke Width", widget::number);
+        MG_PROPERTY("radius", "Corner Radius", widget::number);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/elements/primitives/TextElement.h
+++ b/include/multigauge/gauge/elements/primitives/TextElement.h
@@ -37,14 +37,14 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Text", {
-        MG_PROPERTY("text", "Content", "text");
-        MG_PROPERTY("paint.family", "Font", "text");
-        MG_PROPERTY("paint.pt", "Size", "number");
-        MG_PROPERTY("paint.color", "Color", "color");
+        MG_PROPERTY("text", "Content", widget::text);
+        MG_PROPERTY("paint.family", "Font", widget::text);
+        MG_PROPERTY("paint.pt", "Size", widget::number);
+        MG_PROPERTY("paint.color", "Color", widget::color);
     });
     MG_SECTION("Wrapping", {
-        MG_PROPERTY("ellipses", "Ellipses", "boolean");
-        MG_PROPERTY("hyphens", "Hyphens", "boolean");
+        MG_PROPERTY("ellipses", "Ellipses", widget::boolean);
+        MG_PROPERTY("hyphens", "Hyphens", widget::boolean);
     });
     MG_INCLUDE("layout");
     MG_INSPECTOR_END()

--- a/include/multigauge/gauge/ticks/RootTick.h
+++ b/include/multigauge/gauge/ticks/RootTick.h
@@ -61,16 +61,16 @@ struct RootTick : public ::mg::PropertyObject {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Spacing", {
-        MG_PROPERTY("useDivisions", "Use Divisions", "boolean");
-        MG_PROPERTY_IF("divisions", "Divisions", "number", MG_IN("useDivisions", "true"));
-        MG_PROPERTY_IF("interval", "Interval", "number", MG_IN("useDivisions", "false"));
+        MG_PROPERTY("useDivisions", "Use Divisions", widget::boolean);
+        MG_PROPERTY_IF("divisions", "Divisions", widget::number, MG_IN("useDivisions", "true"));
+        MG_PROPERTY_IF("interval", "Interval", widget::number, MG_IN("useDivisions", "false"));
     });
     MG_SECTION("Appearance", {
-        MG_PROPERTY("length", "Length", "number");
-        MG_PROPERTY("thickness", "Thickness", "number");
-        MG_PROPERTY("paint.fill", "Fill Gradient", "gradient");
-        MG_PROPERTY("paint.stroke", "Stroke Gradient", "gradient");
-        MG_PROPERTY("paint.thickness", "Stroke Width", "number");
+        MG_PROPERTY("length", "Length", widget::number);
+        MG_PROPERTY("thickness", "Thickness", widget::number);
+        MG_PROPERTY("paint.fill", "Fill Gradient", widget::gradient);
+        MG_PROPERTY("paint.stroke", "Stroke Gradient", widget::gradient);
+        MG_PROPERTY("paint.thickness", "Stroke Width", widget::number);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/gauge/ticks/SubTick.h
+++ b/include/multigauge/gauge/ticks/SubTick.h
@@ -40,9 +40,9 @@ struct SubTick : public ::mg::PropertyObject {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Subticks", {
-        MG_PROPERTY("divisions", "Divisions", "number");
-        MG_PROPERTY("length", "Length", "number");
-        MG_PROPERTY("thickness", "Thickness", "number");
+        MG_PROPERTY("divisions", "Divisions", widget::number);
+        MG_PROPERTY("length", "Length", widget::number);
+        MG_PROPERTY("thickness", "Thickness", widget::number);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/gauge/ticks/TickList.h
+++ b/include/multigauge/gauge/ticks/TickList.h
@@ -147,8 +147,8 @@ public:
     MG_INSPECTOR_BEGIN()
     MG_INCLUDE("root");
     MG_SECTION("Subticks", {
-        MG_PROPERTY("subs", "Levels", "tick-levels");
-        MG_PROPERTY("offset", "Offset", "number");
+        MG_PROPERTY("subs", "Levels", widget::tickLevels);
+        MG_PROPERTY("offset", "Offset", widget::number);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/graphics/TextPaint.h
+++ b/include/multigauge/graphics/TextPaint.h
@@ -29,9 +29,9 @@ struct TextPaint : public ::mg::PropertyObject {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Typography", {
-        MG_PROPERTY("family", "Font", "text");
-        MG_PROPERTY("pt", "Size", "number");
-        MG_PROPERTY("color", "Color", "color");
+        MG_PROPERTY("family", "Font", widget::text);
+        MG_PROPERTY("pt", "Size", widget::number);
+        MG_PROPERTY("color", "Color", widget::color);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/graphics/colors/Color.h
+++ b/include/multigauge/graphics/colors/Color.h
@@ -59,9 +59,9 @@ struct Paint : public ::mg::PropertyObject {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Paint", {
-        MG_PROPERTY("fill", "Fill", "color");
-        MG_PROPERTY("stroke", "Stroke", "color");
-        MG_PROPERTY("thickness", "Stroke Width", "number");
+        MG_PROPERTY("fill", "Fill", widget::color);
+        MG_PROPERTY("stroke", "Stroke", widget::color);
+        MG_PROPERTY("thickness", "Stroke Width", widget::number);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/graphics/colors/ColorTimeline.h
+++ b/include/multigauge/graphics/colors/ColorTimeline.h
@@ -21,8 +21,8 @@ struct ColorKeyframe : public ::mg::PropertyObject {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Gradient Stop", {
-        MG_PROPERTY("pos", "Position", "number");
-        MG_PROPERTY("color", "Color", "color");
+        MG_PROPERTY("pos", "Position", widget::number);
+        MG_PROPERTY("color", "Color", widget::color);
     });
     MG_INSPECTOR_END()
 #endif
@@ -50,7 +50,7 @@ class ColorTimeline : public ::mg::PropertyObject {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Gradient", {
-        MG_PROPERTY("keyframes", "Stops", "gradient");
+        MG_PROPERTY("keyframes", "Stops", widget::gradient);
     });
     MG_INSPECTOR_END()
 #endif
@@ -102,9 +102,9 @@ struct PaintTimeline : public ::mg::PropertyObject {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Paint", {
-        MG_PROPERTY("fill", "Fill Gradient", "gradient");
-        MG_PROPERTY("stroke", "Stroke Gradient", "gradient");
-        MG_PROPERTY("thickness", "Stroke Width", "number");
+        MG_PROPERTY("fill", "Fill Gradient", widget::gradient);
+        MG_PROPERTY("stroke", "Stroke Gradient", widget::gradient);
+        MG_PROPERTY("thickness", "Stroke Width", widget::number);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/graphics/colors/StaticColor.h
+++ b/include/multigauge/graphics/colors/StaticColor.h
@@ -17,7 +17,7 @@ class StaticColor final : public Color {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Color", {
-        MG_PROPERTY("color", "Color", "color");
+        MG_PROPERTY("color", "Color", widget::color);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/graphics/colors/TimeColor.h
+++ b/include/multigauge/graphics/colors/TimeColor.h
@@ -35,11 +35,11 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Animation", {
-        MG_PROPERTY("loop", "Loop", "select");
-        MG_PROPERTY("periodMs", "Period (ms)", "number");
+        MG_PROPERTY("loop", "Loop", widget::select);
+        MG_PROPERTY("periodMs", "Period (ms)", widget::number);
     });
     MG_SECTION("Gradient", {
-        MG_PROPERTY("timeline", "Stops", "gradient");
+        MG_PROPERTY("timeline", "Stops", widget::gradient);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/graphics/colors/UserColor.h
+++ b/include/multigauge/graphics/colors/UserColor.h
@@ -27,7 +27,7 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Color", {
-        MG_PROPERTY("slot", "Palette Slot", "select");
+        MG_PROPERTY("slot", "Palette Slot", widget::select);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/graphics/colors/ValueColor.h
+++ b/include/multigauge/graphics/colors/ValueColor.h
@@ -21,8 +21,8 @@ class ValueColor final : public Color {
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Value Color", {
-        MG_PROPERTY("id", "Value ID", "text");
-        MG_PROPERTY("timeline", "Stops", "gradient");
+        MG_PROPERTY("id", "Value ID", widget::text);
+        MG_PROPERTY("timeline", "Stops", widget::gradient);
     });
     MG_INSPECTOR_END()
 #endif

--- a/include/multigauge/properties/PropertyBuilder.h
+++ b/include/multigauge/properties/PropertyBuilder.h
@@ -1,198 +1,100 @@
 #pragma once
 
-#include <memory>
-#include <optional>
-#include <concepts>
-#include <functional>
-#include <type_traits>
 #include <utility>
 
-#include <multigauge/json/Json.h>
+#include <multigauge/properties/PropertyTraits.h>
 
-#include <multigauge/properties/Property.h>
-#include <multigauge/properties/PropertyCodec.h>
-#include <multigauge/properties/PolymorphicRegistry.h>
+namespace mg::props {
+namespace detail {
 
-//----------[ PARENT CHAIN ]----------//
-
-namespace mg {
-
-/// Declares whether a property value type accepts JSON null.
-template <typename T>
-struct PropertyNullableTraits {
-    static constexpr bool value = false;
-};
-
-template <typename T>
-struct PropertyNullableTraits<std::optional<T>> {
-    static constexpr bool value = true;
-};
-
-/// Resolves the parent property-list getter exposed by `MG_PROPS_PARENT`.
 template <typename T>
 constexpr ::mg::PropertyObject::PropertyList::ParentGetter parentPropertyListGetter() {
     if constexpr (requires { &T::__mg_parent_property_list; }) return &T::__mg_parent_property_list;
     return nullptr;
 }
 
-} // namespace mg
-
-//----------[ BUILDERS ]----------//
-
-namespace mg::props {
-
-namespace detail {
-
-//----------[ MEMBER TRAITS ]----------//
-
-/// Extracts the owning class and member type from a member pointer.
-template <typename M>
-struct MemberPtrTraits;
-
-/// Member-pointer specialization used by property builders.
-template <typename C, typename T>
-struct MemberPtrTraits<T C::*> {
-    using Class = C;
-    using Type = T;
-};
-
-template <auto MemberPtr>
-using MemberClass = typename MemberPtrTraits<decltype(MemberPtr)>::Class;
-
-template <auto MemberPtr>
-using MemberType = typename MemberPtrTraits<decltype(MemberPtr)>::Type;
-
-/// A data member of a public `PropertyObject` subtype whose value can be
-/// serialized by the property system.
-template <auto MemberPtr>
-concept PropertyMember = std::is_member_object_pointer_v<decltype(MemberPtr)> &&
-    requires { typename MemberPtrTraits<decltype(MemberPtr)>::Class; typename MemberPtrTraits<decltype(MemberPtr)>::Type; } &&
-    std::derived_from<MemberClass<MemberPtr>, ::mg::PropertyObject>;
-
-/// A no-argument member callback that can be invoked on the member owner.
-template <auto CallbackPtr, typename Owner>
-concept PropertyCallback = std::is_null_pointer_v<decltype(CallbackPtr)> ||
-    requires(Owner& owner) { std::invoke(CallbackPtr, owner); };
-
-//----------[ VALUE ACCESS ]----------//
-
-/// Property setter adapter for a concrete member pointer.
-/// @tparam MemberPtr Pointer to the member being assigned.
-/// @tparam CallbackPtr Optional callback invoked after assignment.
 template <auto MemberPtr, auto CallbackPtr>
     requires PropertyMember<MemberPtr> && PropertyCallback<CallbackPtr, MemberClass<MemberPtr>>
 bool setMember(::mg::PropertyObject* obj, json::Reader value) {
     using C = MemberClass<MemberPtr>;
     using T = MemberType<MemberPtr>;
+
     C* self = static_cast<C*>(obj);
 
     if constexpr (::mg::PropertyObjectValue<T>) {
-    if (!decodeAny<T>(value, self->*MemberPtr)) return false;
+        if (!decodeAny<T>(value, self->*MemberPtr)) return false;
     } else {
         T decoded{};
         if (!decodeAny<T>(value, decoded)) return false;
         self->*MemberPtr = std::move(decoded);
     }
 
-    if constexpr (!std::is_same_v<decltype(CallbackPtr), std::nullptr_t>) {
-        std::invoke(CallbackPtr, *self);
-    }
+    if constexpr (!std::is_same_v<decltype(CallbackPtr), std::nullptr_t>) std::invoke(CallbackPtr, *self);
     return true;
 }
 
-/// Property getter adapter for a concrete member pointer.
-/// @tparam MemberPtr Pointer to the member being serialized.
 template <auto MemberPtr>
     requires PropertyMember<MemberPtr>
 bool getMember(const ::mg::PropertyObject* obj, json::Writer& writer) {
     using C = MemberClass<MemberPtr>;
-    const C* self = static_cast<const C*>(obj);
-    return encodeAny(writer, self->*MemberPtr);
+    return encodeAny(writer, static_cast<const C*>(obj)->*MemberPtr);
 }
 
-//----------[ CHILD OBJECTS ]----------//
-
-/// Detects whether a member exposes a nested `PropertyObject`.
-template <typename T, typename = void>
-struct ChildObjectTraits {
-    static constexpr bool supported = false;
-
-    static const ::mg::PropertyObject* getConst(const T&) { return nullptr; }
-};
-
-/// Nested-child support for direct `PropertyObject` members.
-template <PropertyObjectValue T>
-struct ChildObjectTraits<T> {
-    static constexpr bool supported = true;
-
-    static const ::mg::PropertyObject* getConst(const T& value) { return &value; }
-};
-
-/// Nested-child support for owned `PropertyObject` pointers.
-template <PropertyObjectValue T>
-struct ChildObjectTraits<std::unique_ptr<T>> {
-    static constexpr bool supported = true;
-
-    static const ::mg::PropertyObject* getConst(const std::unique_ptr<T>& value) { return value.get(); }
-};
-
-/// Nested-child support for optional `PropertyObject` members.
-template <PropertyObjectValue T>
-struct ChildObjectTraits<std::optional<T>> {
-    static constexpr bool supported = true;
-
-    static const ::mg::PropertyObject* getConst(const std::optional<T>& value) { return value ? &(*value) : nullptr; }
-};
-
-/// Returns the child object exposed by a member pointer.
 template <auto MemberPtr>
     requires PropertyMember<MemberPtr>
 const ::mg::PropertyObject* getChildObject(const ::mg::PropertyObject* obj) {
     using C = MemberClass<MemberPtr>;
     using T = MemberType<MemberPtr>;
+
     static_assert(ChildObjectTraits<T>::supported, "Member must expose a PropertyObject child.");
+
+    return ChildObjectTraits<T>::getConst(static_cast<const C*>(obj)->*MemberPtr);
+}
+
+template <auto MemberPtr>
+    requires PropertyMember<MemberPtr> && PolymorphicCollectionTraits<MemberType<MemberPtr>>::supported
+bool writeCollectionItems(const ::mg::PropertyObject* obj, json::Writer& writer) {
+    using C = MemberClass<MemberPtr>;
+    
     const C* self = static_cast<const C*>(obj);
-    return ChildObjectTraits<T>::getConst(self->*MemberPtr);
+
+    return writer.writeArray([&](json::ArrayWriter& items) {
+        for (const auto& item : self->*MemberPtr) {
+            if (!items.writeObject([&](json::ObjectWriter& entry) {
+                if (!item) return entry.writeValue("type", [](json::Writer& value) { return value.null(); });
+                if (!entry.write("type", item->typeId() ? item->typeId() : "")) return false;
+                return entry.writeValue("inspector", [&](json::Writer& inspector) {
+                    return item->writeInspectorMeta(inspector);
+                });
+            })) return false;
+        }
+        return true;
+    });
 }
 
 } // namespace detail
 
-//----------[ PROPERTY BUILDERS ]----------//
-
-/// Builds a `Property` descriptor for a concrete member pointer.
-/// @tparam MemberPtr Pointer to the member exposed as a property.
-/// @tparam CallbackPtr Optional callback invoked after successful assignment.
-/// @param key Serialized property key.
 template <auto MemberPtr, auto CallbackPtr = nullptr>
 ::mg::Property makeProperty(const char* key)
     requires detail::PropertyMember<MemberPtr> && detail::PropertyCallback<CallbackPtr, detail::MemberClass<MemberPtr>> {
     using T = detail::MemberType<MemberPtr>;
-
-    ::mg::Property p{};
-    p.key = key;
-    p.set = &detail::setMember<MemberPtr, CallbackPtr>;
-    p.get = &detail::getMember<MemberPtr>;
-
-    if constexpr (detail::ChildObjectTraits<T>::supported) {
-        p.getChild = &detail::getChildObject<MemberPtr>;
-    }
-
+    ::mg::Property p{key, &detail::setMember<MemberPtr, CallbackPtr>, &detail::getMember<MemberPtr>, nullptr};
+    if constexpr (detail::ChildObjectTraits<T>::supported) p.getChild = &detail::getChildObject<MemberPtr>;
 #if MG_BUILD_EDITOR
     ::mg::PropertyMetadata meta{};
     meta.nullable = PropertyNullableTraits<T>::value;
     if constexpr (::mg::EnumDescribed<::mg::EnumTraitsTypeT<T>>) meta.getOptions = &::mg::enumOptionsMeta<::mg::EnumTraitsTypeT<T>>;
     if constexpr (::mg::MgPolymorphicRegistryTraits<T>::supported) meta.getTypes = &::mg::MgPolymorphicRegistryTraits<T>::getTypesMeta;
-
+    if constexpr (detail::PolymorphicCollectionTraits<T>::supported) {
+        meta.getTypes = &detail::PolymorphicCollectionTraits<T>::getTypesMeta;
+        meta.getCollectionItems = &detail::writeCollectionItems<MemberPtr>;
+    }
     return {p.key, p.set, p.get, p.getChild, meta};
 #else
     return p;
 #endif
 }
 
-/// Builds a `Property` descriptor from custom setter and getter functions.
-/// @param key Serialized property key.
-/// @param set Custom setter function.
-/// @param get Custom getter function.
 inline ::mg::Property makeCustomProperty(const char* key, ::mg::Property::Setter set, ::mg::Property::Getter get) {
 #if MG_BUILD_EDITOR
     ::mg::PropertyMetadata meta{};
@@ -206,35 +108,26 @@ inline ::mg::Property makeCustomProperty(const char* key, ::mg::Property::Setter
 
 //----------[ MACROS ]----------//
 
-/** Declares the parent property list for an inherited property hierarchy. */
 #define MG_PROPS_PARENT(parent_type) \
     public: \
     static ::mg::PropertyObject::PropertyList __mg_parent_property_list(const ::mg::PropertyObject* __mg_obj) { \
         return static_cast<const parent_type*>(__mg_obj)->parent_type::propertyList(); \
     }
 
-/** Begins a `propertyList()` override backed by a static `Property` array. */
 #define MG_PROPS_BEGIN() \
 public: \
     ::mg::PropertyObject::PropertyList propertyList() const override { \
         using Self = std::remove_cv_t<std::remove_reference_t<decltype(*this)>>; \
         static const ::mg::Property props[] = {
 
-/** Declares a standard member-backed property. */
-#define MG_PROP(member, key) \
-    ::mg::props::makeProperty<&Self::member, nullptr>(key),
+#define MG_PROP(member, key) ::mg::props::makeProperty<&Self::member, nullptr>(key),
 
-/** Declares a member-backed property with a post-set callback. */
-#define MG_PROP_CALLBACK(member, key, callback) \
-    ::mg::props::makeProperty<&Self::member, callback>(key),
+#define MG_PROP_CALLBACK(member, key, callback) ::mg::props::makeProperty<&Self::member, callback>(key),
 
-/** Declares a property backed by explicit setter and getter functions. */
-#define MG_PROP_CUSTOM(key, set_fn, get_fn) \
-    ::mg::props::makeCustomProperty(key, set_fn, get_fn),
+#define MG_PROP_CUSTOM(key, set_fn, get_fn) ::mg::props::makeCustomProperty(key, set_fn, get_fn),
 
-/** Ends a `propertyList()` override and returns the static property list. */
 #define MG_PROPS_END() \
         }; \
-        const auto parentGetter = ::mg::parentPropertyListGetter<Self>(); \
+        const auto parentGetter = ::mg::props::detail::parentPropertyListGetter<Self>(); \
         return { props, sizeof(props) / sizeof(props[0]), parentGetter }; \
     }

--- a/include/multigauge/properties/PropertyTraits.h
+++ b/include/multigauge/properties/PropertyTraits.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <concepts>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+#include <multigauge/properties/PolymorphicRegistry.h>
+#include <multigauge/properties/PropertyCodec.h>
+#include <multigauge/properties/Property.h>
+
+namespace mg {
+
+//----------[ NULLABLE ]----------//
+
+/// Declares whether a property value type accepts JSON null.
+template <typename T>
+struct PropertyNullableTraits { static constexpr bool value = false; };
+
+template <typename T>
+struct PropertyNullableTraits<std::optional<T>> { static constexpr bool value = true; };
+
+namespace props::detail {
+
+//----------[ MEMBER ]----------//
+
+template <typename M>
+struct MemberPtrTraits;
+
+template <typename C, typename T>
+struct MemberPtrTraits<T C::*> { using Class = C; using Type = T; };
+
+template <auto MemberPtr>
+using MemberClass = typename MemberPtrTraits<decltype(MemberPtr)>::Class;
+
+template <auto MemberPtr>
+using MemberType = typename MemberPtrTraits<decltype(MemberPtr)>::Type;
+
+template <auto MemberPtr>
+concept PropertyMember =
+    std::is_member_object_pointer_v<decltype(MemberPtr)> &&
+    requires {
+        typename MemberPtrTraits<decltype(MemberPtr)>::Class;
+        typename MemberPtrTraits<decltype(MemberPtr)>::Type;
+    } &&
+    std::derived_from<MemberClass<MemberPtr>, ::mg::PropertyObject>;
+
+template <auto CallbackPtr, typename Owner>
+concept PropertyCallback =
+    std::is_null_pointer_v<decltype(CallbackPtr)> ||
+    requires(Owner& owner) {
+        std::invoke(CallbackPtr, owner);
+    };
+
+//----------[ CHILD ]----------//
+
+/// Detects whether a property value exposes a nested `PropertyObject`.
+template <typename T>
+struct ChildObjectTraits {
+    static constexpr bool supported = false;
+    static const ::mg::PropertyObject* getConst(const T&) { return nullptr; }
+};
+
+template <PropertyObjectValue T>
+struct ChildObjectTraits<T> {
+    static constexpr bool supported = true;
+    static const ::mg::PropertyObject* getConst(const T& value) { return &value; }
+};
+
+template <PropertyObjectValue T>
+struct ChildObjectTraits<std::optional<T>> {
+    static constexpr bool supported = true;
+    static const ::mg::PropertyObject* getConst(const std::optional<T>& value) { return value ? &(*value) : nullptr; }
+};
+
+template <PropertyObjectValue T>
+struct ChildObjectTraits<std::unique_ptr<T>> {
+    static constexpr bool supported = true;
+    static const ::mg::PropertyObject* getConst(const std::unique_ptr<T>& value) { return value.get(); }
+};
+
+//----------[ POLYMORPHIC COLLECTION ]----------//
+
+/// Detects a vector of owned polymorphic `PropertyObject`s.
+template <typename T>
+struct PolymorphicCollectionTraits { static constexpr bool supported = false; };
+
+template <typename Base>
+    requires std::derived_from<Base, ::mg::PropertyObject> &&
+             ::mg::MgPolymorphicRegistryTraits<std::unique_ptr<Base>>::supported
+struct PolymorphicCollectionTraits<std::vector<std::unique_ptr<Base>>> {
+    static constexpr bool supported = true;
+    using Owned = std::unique_ptr<Base>;
+
+    static bool getTypesMeta(json::Writer& writer) {
+        return ::mg::MgPolymorphicRegistryTraits<Owned>::getTypesMeta(writer);
+    }
+};
+
+} // namespace props::detail
+
+} // namespace mg

--- a/include/multigauge/properties/meta/Inspector.h
+++ b/include/multigauge/properties/meta/Inspector.h
@@ -9,6 +9,7 @@
 
 #include <multigauge/json/Json.h>
 #include <multigauge/properties/meta/Rules.h>
+#include <multigauge/properties/meta/Widgets.h>
 
 namespace mg {
 

--- a/include/multigauge/properties/meta/PropertyMetadata.h
+++ b/include/multigauge/properties/meta/PropertyMetadata.h
@@ -10,10 +10,12 @@ class PropertyObject; // Forward declaration
 struct PropertyMetadata {
     using OptionsGetter = bool (*)(json::Writer&);
     using TypeListGetter = bool (*)(json::Writer&);
+    using CollectionItemsGetter = bool (*)(const PropertyObject*, json::Writer&);
 
     bool nullable = false; ///< Whether JSON null is a valid property value.
     OptionsGetter getOptions = nullptr; ///< Retrieves the finite set of valid values, when applicable.
     TypeListGetter getTypes = nullptr; ///< Retrieves valid concrete types for a polymorphic property.
+    CollectionItemsGetter getCollectionItems = nullptr; ///< Retrieves inspector metadata for each item in a collection.
 };
 
 }

--- a/include/multigauge/properties/meta/Widgets.h
+++ b/include/multigauge/properties/meta/Widgets.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace mg::widget {
+
+inline constexpr const char* text = "text";
+inline constexpr const char* number = "number";
+inline constexpr const char* boolean = "boolean";
+inline constexpr const char* select = "select";
+inline constexpr const char* json = "json";
+inline constexpr const char* color = "color";
+inline constexpr const char* gradient = "gradient";
+inline constexpr const char* valueRef = "value-ref";
+inline constexpr const char* layoutSize = "layout-size";
+inline constexpr const char* tickLevels = "tick-levels";
+inline constexpr const char* collection = "collection";
+inline constexpr const char* directionToggle = "direction-toggle";
+inline constexpr const char* alignmentGrid = "alignment-grid";
+inline constexpr const char* insets = "insets";
+inline constexpr const char* anchorPair = "anchor-pair";
+inline constexpr const char* axisPair = "axis-pair";
+
+} // namespace mg::widget

--- a/include/multigauge/value/ValueView.h
+++ b/include/multigauge/value/ValueView.h
@@ -78,12 +78,12 @@ private:
 #if MG_BUILD_EDITOR
     MG_INSPECTOR_BEGIN()
     MG_SECTION("Value", {
-        MG_PROPERTY("id", "ID", "text");
+        MG_PROPERTY("id", "ID", widget::text);
         MG_ROW({
-            MG_PROPERTY("min", "Minimum", "number");
-            MG_PROPERTY("max", "Maximum", "number");
+            MG_PROPERTY("min", "Minimum", widget::number);
+            MG_PROPERTY("max", "Maximum", widget::number);
         });
-        MG_PROPERTY("unitIndex", "Unit Index", "number");
+        MG_PROPERTY("unitIndex", "Unit Index", widget::number);
     });
     MG_INSPECTOR_END()
 #endif

--- a/src/properties/PropertyObject.cpp
+++ b/src/properties/PropertyObject.cpp
@@ -94,7 +94,14 @@ bool PropertyObject::writePropertyMeta(json::Writer& writer, const Property& pro
                        return child->writeInspectorLayout(layout);
                    });
         }
-        return object.writeValue("value", [&](json::Writer& value) { return prop.get ? prop.get(this, value) : value.null(); });
+        if (!object.writeValue("value", [&](json::Writer& value) { return prop.get ? prop.get(this, value) : value.null(); })) return false;
+        if (!prop.meta.getCollectionItems) return true;
+        return object.writeObject("collection", [&](json::ObjectWriter& collection) {
+            return (!prop.meta.getTypes || collection.writeValue("types", prop.meta.getTypes)) &&
+                   collection.writeValue("items", [&](json::Writer& items) {
+                       return prop.meta.getCollectionItems(this, items);
+                   });
+        });
     });
 #endif
 }

--- a/tests/test_gauge.cpp
+++ b/tests/test_gauge.cpp
@@ -500,6 +500,53 @@ TEST_CASE("gauge face round-trips radial parts") {
     CHECK(savedAgain.toString() == document.toString());
 }
 
+TEST_CASE("radial parts expose embedded polymorphic collection inspector metadata") {
+#if MG_BUILD_EDITOR
+    mg::gauge::Radial radial;
+    const auto parts = mg::json::parse(
+        R"([{"type":"scale","radius":1,"ticks":{"root":{},"subs":[]}},{"type":"needle","radius":0.75}])"
+    );
+    REQUIRE(parts.valid());
+    REQUIRE(radial.setProperty("parts", parts.root()));
+
+    auto metadata = mg::json::array();
+    auto writer = metadata.writer();
+    REQUIRE(radial.writePropertiesMeta(writer));
+
+    mg::json::Reader partsMeta;
+    for (std::size_t index = 0; index < metadata.root().size(); ++index) {
+        const auto candidate = metadata.root().element(index);
+        std::string_view key;
+        if (candidate.member("key").read(key) && key == "parts") {
+            partsMeta = candidate;
+            break;
+        }
+    }
+    REQUIRE(partsMeta.valid());
+    CHECK(partsMeta.member("value").isArray());
+    const auto collection = partsMeta.member("collection");
+    REQUIRE(collection.isObject());
+    REQUIRE(collection.member("types").isArray());
+    CHECK(collection.member("types").size() == 2);
+    REQUIRE(collection.member("items").isArray());
+    CHECK(collection.member("items").size() == 2);
+
+    std::string_view firstType;
+    REQUIRE(collection.member("items").element(0).member("type").read(firstType));
+    CHECK(firstType == "scale");
+    const auto scaleInspector = collection.member("items").element(0).member("inspector");
+    CHECK(scaleInspector.member("properties").isArray());
+    CHECK(scaleInspector.member("layout").isArray());
+
+    std::string_view secondType;
+    REQUIRE(collection.member("items").element(1).member("type").read(secondType));
+    CHECK(secondType == "needle");
+    const auto needleInspector = collection.member("items").element(1).member("inspector");
+    CHECK(needleInspector.member("properties").isArray());
+    CHECK(needleInspector.member("layout").isArray());
+#endif
+}
+
 TEST_CASE("gauge element codec owns type and property serialization") {
     auto element = mg::gauge::Element::registry().create("rectangle");
     REQUIRE(element != nullptr);


### PR DESCRIPTION
##  What changed?

- Added editor-only metadata support for embedded polymorphic `PropertyObject` collections.
- `Radial::parts` now exposes its registered part types and each part’s normal inspector metadata. The core also centralizes inspector widget IDs and moves property-type traits into `PropertyTraits.h`.
- Replaced the temporary radial-specific inspector widget ID, `radial-parts`, with the reusable collection widget ID.
- Centralized core inspector widget IDs in `Widgets.h`; inspector layouts now use `widget::...` constants instead of raw strings.
## Why?

Editors need to render and edit polymorphic collections such as radial Needle and Scale parts without treating them as gauge-tree nodes or relying on radial-specific UI logic.

## Implementation notes

Collection metadata is only compiled for editor builds. Runtime serialization remains unchanged: editors update an item locally, then write the complete collection through its root property.

## Checklist

- [X] This PR is limited to one logical feature or change
- [X] Public APIs, configuration, or documentation were updated if needed.
- [X] No debugging code, temporary files, or unrelated changes are included